### PR TITLE
Initial REST api for heartbeat.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,9 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: Check for formatting errors
         run: test -z $(gofmt -l .)
-      - name: Build and test Go
+      - name: Build and test Go with race detector
+        run: go test ./... -race
+      - name: Build and test Go with coverage
         run: go test ./... -coverprofile cover.out
         # upload cover.out as an artifact so we can generate a web view on failure
       - name: Upload coverage profile

--- a/cmd/groundstation/main.go
+++ b/cmd/groundstation/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/gpuctl/gpuctl/cmd/groundstation/config"
@@ -27,23 +28,44 @@ func main() {
 	http.HandleFunc("/api/remote", remote.HandleStatusSubmission)
 	http.ListenAndServe(config.PortToAddress(configuration.Server.Port), nil)
 
-	mux := new(femto.Femto)
-	gs := groundstation{
-		lastSeen: make(map[string]time.Time),
-	}
-	femto.OnPost(mux, uplink.HeartbeatUrl, gs.heartbeat)
+	srv := NewServer()
+
+	http.ListenAndServe(":8080", srv)
 
 	// TODO: Make this configurable
-	err = mux.ListenAndServe(":8080")
+	// err = mux.ListenAndServe(":8080")
 	slog.Info("Shut down groundstation", "err", err)
+}
+
+type Server struct {
+	mux *femto.Femto
+	gs  groundstation
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+func NewServer() *Server {
+	mux := new(femto.Femto)
+	gs := groundstation{lastSeen: make(map[string]time.Time)}
+
+	/// Register routes.
+	femto.OnPost(mux, uplink.HeartbeatUrl, gs.heartbeat)
+
+	return &Server{mux, gs}
 }
 
 type groundstation struct {
 	lastSeen map[string]time.Time
+	mu       sync.Mutex
 }
 
 func (gs *groundstation) heartbeat(data uplink.HeartbeatReq, req *http.Request, log *slog.Logger) error {
 	// TODO: Pull out just the IP here.
+	gs.mu.Lock()
+	defer gs.mu.Unlock()
+
 	from := req.RemoteAddr
 	prev := gs.lastSeen[from]
 

--- a/cmd/groundstation/main.go
+++ b/cmd/groundstation/main.go
@@ -2,24 +2,54 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/gpuctl/gpuctl/cmd/groundstation/config"
 	"github.com/gpuctl/gpuctl/cmd/groundstation/remote"
+	"github.com/gpuctl/gpuctl/internal/femto"
+	"github.com/gpuctl/gpuctl/internal/uplink"
 )
 
 func main() {
-	fmt.Print("Hey, world :3")
+	slog.Info("Starting groundstation")
 
 	configuration, err := config.GetConfiguration("config.toml")
 
 	if err != nil {
 		// TODO: Using logging library for auditing, fail soft
 		fmt.Println("Error detected when determining configuration")
+		return
 	}
 
+	// TODO: Move this into fempto.
 	http.HandleFunc("/api/remote", remote.HandleStatusSubmission)
-
 	http.ListenAndServe(config.PortToAddress(configuration.Server.Port), nil)
 
+	mux := new(femto.Femto)
+	gs := groundstation{
+		lastSeen: make(map[string]time.Time),
+	}
+	femto.OnPost(mux, uplink.HeartbeatUrl, gs.heartbeat)
+
+	// TODO: Make this configurable
+	err = mux.ListenAndServe(":8080")
+	slog.Info("Shut down groundstation", "err", err)
+}
+
+type groundstation struct {
+	lastSeen map[string]time.Time
+}
+
+func (gs *groundstation) heartbeat(data uplink.HeartbeatReq, req *http.Request, log *slog.Logger) error {
+	// TODO: Pull out just the IP here.
+	from := req.RemoteAddr
+	prev := gs.lastSeen[from]
+
+	gs.lastSeen[from] = data.Time
+
+	log.Info("Received a heartbeat", "prev_time", prev, "cur_time", data.Time)
+
+	return nil
 }

--- a/cmd/groundstation/server_test.go
+++ b/cmd/groundstation/server_test.go
@@ -1,0 +1,44 @@
+package main_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	gs "github.com/gpuctl/gpuctl/cmd/groundstation"
+	"github.com/gpuctl/gpuctl/internal/uplink"
+)
+
+func TestHeartbeatRace(t *testing.T) {
+	t.Parallel()
+
+	srv := gs.NewServer()
+	var wg sync.WaitGroup
+
+	toSpawn := 100
+	wg.Add(toSpawn)
+
+	failed := false
+
+	for i := 0; i < toSpawn; i++ {
+		go func() {
+
+			req := httptest.NewRequest(http.MethodPost, uplink.HeartbeatUrl, bytes.NewBufferString(`{}`))
+			resp := httptest.NewRecorder()
+			srv.ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusOK {
+				failed = true
+			}
+
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	if failed {
+		t.Error("one of the responces didn't return 200")
+	}
+}

--- a/internal/femto/client.go
+++ b/internal/femto/client.go
@@ -1,0 +1,27 @@
+package femto
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+// Post data to the given URL
+func Post[T any](url string, data T) error {
+	// TODO:
+	// - Logging
+	// - Customizable transport
+
+	body, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.Post(url, "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+
+	return err
+}

--- a/internal/femto/client_test.go
+++ b/internal/femto/client_test.go
@@ -1,0 +1,23 @@
+package femto_test
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/gpuctl/gpuctl/internal/femto"
+)
+
+func TestPostToUnresolvable(t *testing.T) {
+	t.Parallel()
+
+	err := femto.Post("https://lol.invalid", 101)
+
+	var target *net.DNSError
+	if !errors.As(err, &target) {
+		t.Fatal("DNS error, but got", err)
+	}
+	if target.Name != "lol.invalid" {
+		t.Fatal("Expected target name `lol.invalid`, but got: ", target.Name)
+	}
+}

--- a/internal/femto/femto.go
+++ b/internal/femto/femto.go
@@ -31,8 +31,8 @@ func doPost[T any](f *Femto, w http.ResponseWriter, r *http.Request, handle Hand
 	log.Info("New Request", "method", r.Method, "url", r.URL, "from", r.RemoteAddr)
 
 	if r.Method != http.MethodPost {
-		log.Info("Wanted GET, returned 405")
-		http.Error(w, "Expected GET", http.StatusMethodNotAllowed)
+		log.Info("Wanted POST, returned 405")
+		http.Error(w, "Expected POST", http.StatusMethodNotAllowed)
 		return
 	}
 

--- a/internal/femto/femto.go
+++ b/internal/femto/femto.go
@@ -1,0 +1,68 @@
+// Package femto provides a tiny abstraction layer for writing API's that serve JSON over HTTP.
+package femto
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+)
+
+type Femto struct {
+	mux   http.ServeMux
+	reqNo atomic.Uint64
+}
+
+func (f *Femto) ListenAndServe(addr string) error {
+	return http.ListenAndServe(addr, &f.mux)
+}
+
+func OnPost[T any](f *Femto, pattern string, handle HandlerFunc[T]) {
+	f.mux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+		doPost(f, w, r, handle)
+	})
+}
+
+func doPost[T any](f *Femto, w http.ResponseWriter, r *http.Request, handle HandlerFunc[T]) {
+
+	reqNo := f.nextReqNo()
+	log := f.logger().With(slog.Uint64("req_no", reqNo))
+
+	log.Info("New Request", "method", r.Method, "url", r.URL, "from", r.RemoteAddr)
+
+	if r.Method != http.MethodPost {
+		log.Info("Wanted GET, returned 405")
+		http.Error(w, "Expected GET", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// TODO: Ensure all field's are present. I'm so mad this is hard.
+	var reqData T
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&reqData); err != nil {
+		log.Info("Failed to unmarshal JSON", "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	userErr := handle(reqData, r, log)
+	if userErr != nil {
+		// TODO: Nicer error
+		log.Info("Error", "err", userErr)
+		http.Error(w, userErr.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Write([]byte("OK"))
+}
+
+func (f *Femto) nextReqNo() uint64 {
+	return f.reqNo.Add(1)
+}
+
+func (f *Femto) logger() *slog.Logger {
+	// TODO: Associate a logger with Femto.
+	return slog.Default()
+}
+
+type HandlerFunc[T any] func(T, *http.Request, *slog.Logger) error

--- a/internal/femto/femto.go
+++ b/internal/femto/femto.go
@@ -14,7 +14,11 @@ type Femto struct {
 }
 
 func (f *Femto) ListenAndServe(addr string) error {
-	return http.ListenAndServe(addr, &f.mux)
+	return http.ListenAndServe(addr, f)
+}
+
+func (f *Femto) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.mux.ServeHTTP(w, r)
 }
 
 func OnPost[T any](f *Femto, pattern string, handle HandlerFunc[T]) {
@@ -41,7 +45,7 @@ func doPost[T any](f *Femto, w http.ResponseWriter, r *http.Request, handle Hand
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&reqData); err != nil {
 		log.Info("Failed to unmarshal JSON", "error", err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		http.Error(w, "failed to decode json: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/internal/femto/femto.go
+++ b/internal/femto/femto.go
@@ -13,10 +13,6 @@ type Femto struct {
 	reqNo atomic.Uint64
 }
 
-func (f *Femto) ListenAndServe(addr string) error {
-	return http.ListenAndServe(addr, f)
-}
-
 func (f *Femto) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	f.mux.ServeHTTP(w, r)
 }

--- a/internal/femto/server_test.go
+++ b/internal/femto/server_test.go
@@ -1,0 +1,89 @@
+package femto_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gpuctl/gpuctl/internal/femto"
+	"github.com/stretchr/testify/assert"
+)
+
+var _ (http.Handler) = (*femto.Femto)(nil)
+
+func TestError404(t *testing.T) {
+	t.Parallel()
+
+	mux := new(femto.Femto)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+	defer req.Body.Close()
+
+	assert.Equal(t, w.Code, http.StatusNotFound)
+}
+
+func TestWrongMethod(t *testing.T) {
+	t.Parallel()
+
+	mux := new(femto.Femto)
+
+	femto.OnPost[struct{}](mux, "/postme", func(s struct{}, r *http.Request, l *slog.Logger) error {
+		return nil
+	})
+
+	req := httptest.NewRequest("GET", "/postme", nil)
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+	defer req.Body.Close()
+
+	assert.Equal(t, w.Code, http.StatusMethodNotAllowed)
+}
+
+func TestNotJson(t *testing.T) {
+	t.Parallel()
+
+	mux := new(femto.Femto)
+
+	femto.OnPost[struct{}](mux, "/postme", func(s struct{}, r *http.Request, l *slog.Logger) error {
+		return nil
+	})
+
+	req := httptest.NewRequest("POST", "/postme", bytes.NewBufferString("not json at all"))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	defer req.Body.Close()
+
+	assert.Equal(t, w.Code, http.StatusBadRequest)
+
+	data, err := io.ReadAll(w.Body)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "failed to decode json")
+}
+
+func TestUserError(t *testing.T) {
+	t.Parallel()
+
+	mux := new(femto.Femto)
+	femto.OnPost[struct{}](mux, "/postme", func(s struct{}, r *http.Request, l *slog.Logger) error {
+		return errors.New("their is no spoon")
+	})
+
+	req := httptest.NewRequest("POST", "/postme", bytes.NewBufferString("{}"))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	defer req.Body.Close()
+
+	assert.Equal(t, w.Code, http.StatusInternalServerError)
+
+	data, err := io.ReadAll(w.Body)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "their is no spoon")
+}

--- a/internal/femto/server_test.go
+++ b/internal/femto/server_test.go
@@ -40,9 +40,12 @@ func TestWrongMethod(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/postme", nil)
 	w := httptest.NewRecorder()
-
 	mux.ServeHTTP(w, req)
 	defer req.Body.Close()
+
+	data, err := io.ReadAll(w.Body)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "Expected POST")
 
 	assert.Equal(t, w.Code, http.StatusMethodNotAllowed)
 }

--- a/internal/uplink/heartbeat.go
+++ b/internal/uplink/heartbeat.go
@@ -1,0 +1,11 @@
+// package uplink defines the types used in groundstation <-> satiate transport.
+
+package uplink
+
+import "time"
+
+const HeartbeatUrl = "/gs-api/heartbeat/"
+
+type HeartbeatReq struct {
+	Time time.Time
+}


### PR DESCRIPTION
Closes #14

This need a bit more work before being usefull, but I want to land/get your review now, because groundstation<->satellite comunication is important.

Core Ideas:

- `uplink` package defines data format for this communication
  - Any types that need to cross the network here should be defined here.
  - IE we should move `GPUStatsPacket` into here.
- `fempto` contains abstractions for HTTP.

To test:

```go
go run ./cmd/groundstation/
# in another tab:
go run ./cmd/satellite/
```

Which will output something like:

```go
2024/01/18 01:51:05 INFO Starting groundstation
2024/01/18 01:51:08 INFO New Request req_no=3 method=POST url=/gs-api/heartbeat/ from=127.0.0.1:60420
2024/01/18 01:51:08 INFO New Request req_no=1 method=POST url=/gs-api/heartbeat/ from=127.0.0.1:60404
2024/01/18 01:51:08 INFO New Request req_no=2 method=POST url=/gs-api/heartbeat/ from=127.0.0.1:60374
2024/01/18 01:51:08 INFO Received a heartbeat req_no=2 prev_time=0001-01-01T00:00:00.000Z cur_time=2024-01-18T01:51:08.362Z
2024/01/18 01:51:08 INFO New Request req_no=5 method=POST url=/gs-api/heartbeat/ from=127.0.0.1:60394
2024/01/18 01:51:08 INFO Received a heartbeat req_no=1 prev_time=0001-01-01T00:00:00.000Z cur_time=2024-01-18T01:51:08.362Z
2024/01/18 01:51:08 INFO New Request req_no=4 method=POST url=/gs-api/heartbeat/ from=127.0.0.1:60436
2024/01/18 01:51:08 INFO Received a heartbeat req_no=3 prev_time=0001-01-01T00:00:00.000Z cur_time=2024-01-18T01:51:08.362Z
2024/01/18 01:51:08 INFO Received a heartbeat req_no=4 prev_time=0001-01-01T00:00:00.000Z cur_time=2024-01-18T01:51:08.362Z
2024/01/18 01:51:08 INFO Received a heartbeat req_no=5 prev_time=0001-01-01T00:00:00.000Z cur_time=2024-01-18T01:51:08.362Z
2024/01/18 01:51:08 INFO New Request req_no=6 method=POST url=/gs-api/heartbeat/ from=127.0.0.1:60380
2024/01/18 01:51:08 INFO Received a heartbeat req_no=6 prev_time=0001-01-01T00:00:00.000Z cur_time=2024-01-18T01:51:08.362Z
2024/01/18 01:51:08 INFO New Request req_no=7 method=POST url=/gs-api/heartbeat/ from=127.0.0.1:60432
2024/01/18 01:51:08 INFO Received a heartbeat req_no=7 prev_time=0001-01-01T00:00:00.000Z cur_time=2024-01-18T01:51:08.362Z
2024/01/18 01:51:08 INFO New Request req_no=8 method=POST url=/gs-api/heartbeat/ from=127.0.0.1:60454
2024/01/18 01:51:08 INFO Received a heartbeat req_no=8 prev_time=0001-01-01T00:00:00.000Z cur_time=2024-01-18T01:51:08.362Z
2024/01/18 01:51:08 INFO New Request req_no=9 method=POST url=/gs-api/heartbeat/ from=127.0.0.1:60396
2024/01/18 01:51:08 INFO Received a heartbeat req_no=9 prev_time=0001-01-01T00:00:00.000Z cur_time=2024-01-18T01:51:08.362Z
2024/01/18 01:51:08 INFO New Request req_no=10 method=POST url=/gs-api/heartbeat/ from=127.0.0.1:60442
2024/01/18 01:51:08 INFO Received a heartbeat req_no=10 prev_time=0001-01-01T00:00:00.000Z cur_time=2024-01-18T01:51:08.362Z
```

(This probably needs to be automated)