### PR TITLE
Statistic submission endpoint & some data model properties defined

### DIFF
--- a/cmd/groundstation/config/config.go
+++ b/cmd/groundstation/config/config.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+type Configuration struct {
+	Server struct {
+		Port int `toml:"port"`
+	} `toml:"server"`
+}
+
+func DefaultConfiguration() Configuration {
+	return Configuration{
+		Server: struct {
+			Port int `toml:"port"`
+		}{Port: 8080},
+	}
+}
+
+func PortToAddress(port int) string {
+	return fmt.Sprintf(":%d", port)
+}
+
+func GetConfigurationFromPath(configPath string) (Configuration, error) {
+	var config Configuration
+
+	if _, err := toml.DecodeFile(configPath, &config); err != nil {
+		return DefaultConfiguration(), err
+	}
+	return config, nil
+}
+
+func GetConfiguration() (Configuration, error) {
+	exePath, err := os.Executable()
+
+	if err != nil {
+		return DefaultConfiguration(), err
+	}
+
+	exeDir := filepath.Dir(exePath)
+	configPath := filepath.Join(exeDir, "config.toml")
+
+	return GetConfigurationFromPath(configPath)
+}

--- a/cmd/groundstation/config/config_test.go
+++ b/cmd/groundstation/config/config_test.go
@@ -1,22 +1,109 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
-	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetConfigurationFromPath(t *testing.T) {
-	const validConfig = `
-[server]
-port = 9090`
+func createTempConfigFile(content string, t *testing.T) (string, func()) {
+	t.Helper()
 
-	var config Configuration
-	_, err := toml.Decode(validConfig, &config)
+	exePath, err := os.Executable()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpfile, err := os.CreateTemp(filepath.Dir(exePath), "config.toml")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := tmpfile.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return tmpfile.Name(), func() {
+		os.Remove(tmpfile.Name())
+	}
+}
+
+func TestFileEmpty_EmptyCase(t *testing.T) {
+	content := ``
+
+	filename, cleanup := createTempConfigFile(content, t)
+	defer cleanup()
+
+	isEmpty, err := IsFileEmpty(filename)
 
 	assert.NoError(t, err)
+	assert.True(t, isEmpty)
+}
+
+func TestFileEmpty_NonEmptyCase(t *testing.T) {
+	content := `see, it's not empty :)`
+
+	filename, cleanup := createTempConfigFile(content, t)
+	defer cleanup()
+
+	isEmpty, err := IsFileEmpty(filename)
+
+	assert.NoError(t, err)
+	assert.False(t, isEmpty)
+}
+
+func TestFileEmpty_InvalidCase(t *testing.T) {
+	_, err := IsFileEmpty("dummy_path")
+
+	assert.Error(t, err)
+}
+
+func TestGetConfiguration_ValidConfig(t *testing.T) {
+	content := `
+[server]
+port = 9090`
+	filename, cleanup := createTempConfigFile(content, t)
+	defer cleanup()
+
+	filename = filepath.Base(filename)
+
+	config, err := GetConfiguration(filename)
+	assert.NoError(t, err)
 	assert.Equal(t, 9090, config.Server.Port)
+}
+
+func TestGetConfiguration_DefaultConfig(t *testing.T) {
+	content := ``
+
+	filename, cleanup := createTempConfigFile(content, t)
+	defer cleanup()
+
+	filename = filepath.Base(filename)
+
+	config, err := GetConfiguration(filename)
+	assert.NoError(t, err)
+	assert.Equal(t, 8080, config.Server.Port)
+}
+
+func TestGetConfiguration_InvalidConfig(t *testing.T) {
+	content := `
+server: "should be a table, not a string"`
+	filename, cleanup := createTempConfigFile(content, t)
+	defer cleanup()
+
+	filename = filepath.Base(filename)
+
+	config, err := GetConfiguration(filename)
+	assert.NoError(t, err)
+	assert.Equal(t, 8080, config.Server.Port)
 }
 
 func TestPortToAddress(t *testing.T) {

--- a/cmd/groundstation/config/config_test.go
+++ b/cmd/groundstation/config/config_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetConfigurationFromPath(t *testing.T) {
+	const validConfig = `
+[server]
+port = 9090`
+
+	var config Configuration
+	_, err := toml.Decode(validConfig, &config)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 9090, config.Server.Port)
+}
+
+func TestPortToAddress(t *testing.T) {
+	assert.Equal(t, ":9090", PortToAddress(9090))
+}

--- a/cmd/groundstation/main.go
+++ b/cmd/groundstation/main.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"fmt"
-	"github.com/gpuctl/gpuctl/internal/incrementer"
+	"net/http"
+
+	"github.com/gpuctl/gpuctl/cmd/groundstation/remote"
 )
 
 func main() {
-	fmt.Println("Hello from groundstation")
-	fmt.Println(incrementer.Inc(4))
+	fmt.Print("Hey, world :3")
+
+	http.HandleFunc("/api/remote", remote.HandleStatusSubmission)
+
 }

--- a/cmd/groundstation/main.go
+++ b/cmd/groundstation/main.go
@@ -4,12 +4,21 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/gpuctl/gpuctl/cmd/groundstation/config"
 	"github.com/gpuctl/gpuctl/cmd/groundstation/remote"
 )
 
 func main() {
 	fmt.Print("Hey, world :3")
 
+	configuration, err := config.GetConfiguration()
+
+	if err != nil {
+		// TODO: Using logging library for auditing, fail soft
+		fmt.Println("Error detected when determining configuration")
+	}
+
 	http.HandleFunc("/api/remote", remote.HandleStatusSubmission)
 
+	http.ListenAndServe(config.PortToAddress(configuration.Server.Port), nil)
 }

--- a/cmd/groundstation/main.go
+++ b/cmd/groundstation/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	fmt.Print("Hey, world :3")
 
-	configuration, err := config.GetConfiguration()
+	configuration, err := config.GetConfiguration("config.toml")
 
 	if err != nil {
 		// TODO: Using logging library for auditing, fail soft

--- a/cmd/groundstation/remote/remote.go
+++ b/cmd/groundstation/remote/remote.go
@@ -38,9 +38,11 @@ func HandleStatusSubmission(writer http.ResponseWriter, request *http.Request) {
 
 	if err != nil {
 		http.Error(
-			writer, "Expected JSON for status submission",
+			writer, "Malformed request body detected",
 			http.StatusBadRequest,
 		)
+
+		return
 	}
 
 	packet, err := buildStatusObject(body)
@@ -50,6 +52,8 @@ func HandleStatusSubmission(writer http.ResponseWriter, request *http.Request) {
 			writer, "JSON deserialisation was not successful",
 			http.StatusBadRequest,
 		)
+
+		return
 	}
 
 	err = handleGPUStatusObject(packet)
@@ -59,6 +63,8 @@ func HandleStatusSubmission(writer http.ResponseWriter, request *http.Request) {
 			writer, "There was an error while handling the status object",
 			http.StatusInternalServerError,
 		)
+
+		return
 	}
 
 	writer.WriteHeader(http.StatusOK)

--- a/cmd/groundstation/remote/remote.go
+++ b/cmd/groundstation/remote/remote.go
@@ -1,0 +1,66 @@
+package remote
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/gpuctl/gpuctl/internal/status"
+)
+
+func buildStatusObject(jsonData []byte) (status.GPUStatusPacket, error) {
+	var handler status.GPUStatusPacket
+
+	err := json.Unmarshal(jsonData, &handler)
+	if err != nil {
+		return status.GPUStatusPacket{}, err
+	}
+
+	return handler, nil
+}
+
+func handleGPUStatusObject(stat status.GPUStatusPacket) error {
+	return nil
+}
+
+func HandleStatusSubmission(writer http.ResponseWriter, request *http.Request) {
+	if request.Method != "POST" {
+		http.Error(
+			writer, "Invalid method for status submission",
+			http.StatusBadRequest,
+		)
+
+		return
+	}
+
+	body, err := io.ReadAll(request.Body)
+	defer request.Body.Close()
+
+	if err != nil {
+		http.Error(
+			writer, "Expected JSON for status submission",
+			http.StatusBadRequest,
+		)
+	}
+
+	packet, err := buildStatusObject(body)
+
+	if err != nil {
+		http.Error(
+			writer, "JSON deserialisation was not successful",
+			http.StatusBadRequest,
+		)
+	}
+
+	err = handleGPUStatusObject(packet)
+
+	if err != nil {
+		http.Error(
+			writer, "There was an error while handling the status object",
+			http.StatusInternalServerError,
+		)
+	}
+
+	writer.WriteHeader(http.StatusOK)
+	writer.Write([]byte("OK: Submission processed successfully"))
+}

--- a/cmd/groundstation/remote/remote_test.go
+++ b/cmd/groundstation/remote/remote_test.go
@@ -1,0 +1,116 @@
+package remote
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gpuctl/gpuctl/internal/status"
+	"github.com/stretchr/testify/assert"
+)
+
+/* Status Object Construction */
+
+func TestBuildStatusObject(t *testing.T) {
+	validJSON := []byte(`{"gpu_name": "Test GPU", "gpu_brand": "BrandX", "driver_ver": "1.0", "memory_total": 4096, "memory_util": 50, "gpu_util": 50, "memory_used": 2048, "fan_speed": 70, "gpu_temp": 60}`)
+	expectedPacket := status.GPUStatusPacket{
+		Name:              "Test GPU",
+		Brand:             "BrandX",
+		DriverVersion:     "1.0",
+		MemoryTotal:       4096,
+		MemoryUtilisation: 50,
+		GPUUtilisation:    50,
+		MemoryUsed:        2048,
+		FanSpeed:          70,
+		Temp:              60,
+	}
+
+	packet, err := buildStatusObject(validJSON)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedPacket, packet)
+
+}
+
+func TestBuildMalformedObject(t *testing.T) {
+	invalidJSON := []byte(`{"gpu_name": "Test GPU", "gpu_brand": "BrandX", "driver_ver": 1.0}`)
+	_, err := buildStatusObject(invalidJSON)
+
+	assert.Error(t, err)
+}
+
+/* Submission Side-Effect Testing */
+
+type corruptedReader struct{}
+
+func (r corruptedReader) Read(p []byte) (int, error) {
+	return 0, errors.New("Read corrupted")
+}
+
+func simulateCorruptedSubmissionAndGetResponse(method string) *http.Response {
+	req := httptest.NewRequest(method, "/api/submit", &corruptedReader{})
+	w := httptest.NewRecorder()
+
+	HandleStatusSubmission(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	return res
+}
+
+func simulateSubmissionAndGetResponse(submission []byte, method string) *http.Response {
+	req := httptest.NewRequest(method, "/api/submit", bytes.NewBuffer(submission))
+	w := httptest.NewRecorder()
+
+	HandleStatusSubmission(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	return res
+}
+
+func assertResponseHas(t *testing.T, res *http.Response, expectedStatusCode int, expectedMessage string) {
+	assert.Equal(t, expectedStatusCode, res.StatusCode)
+
+	data, err := io.ReadAll(res.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedMessage, string(data))
+}
+
+func TestHandleStatusSubmission(t *testing.T) {
+	validJSON := []byte(`{"gpu_name": "Test GPU", "gpu_brand": "BrandX", "driver_ver": "1.0", "memory_total": 4096, "memory_util": 50, "gpu_util": 50, "memory_used": 2048, "fan_speed": 70, "gpu_temp": 60}`)
+
+	res := simulateSubmissionAndGetResponse(validJSON, "POST")
+
+	assertResponseHas(t, res, http.StatusOK, "OK: Submission processed successfully")
+}
+
+func TestHandleWrongMethodSubmission(t *testing.T) {
+	validJSON := []byte(`{"gpu_name": "Test GPU", "gpu_brand": "BrandX", "driver_ver": "1.0", "memory_total": 4096, "memory_util": 50, "gpu_util": 50, "memory_used": 2048, "fan_speed": 70, "gpu_temp": 60}`)
+
+	res := simulateSubmissionAndGetResponse(validJSON, "GET")
+
+	assertResponseHas(t, res, http.StatusBadRequest, "Invalid method for status submission\n")
+}
+
+func TestHandleBadJsonSubmission(t *testing.T) {
+	res := simulateCorruptedSubmissionAndGetResponse("POST")
+
+	assertResponseHas(t, res, http.StatusBadRequest, "Malformed request body detected\n")
+}
+
+func TestHandleBadJsonDeserialisation(t *testing.T) {
+	invalidJSON := []byte(`{"gpu_name": "Test GPU", "gpu_brand": "BrandX", "driver_ver": 1.0}`)
+
+	res := simulateSubmissionAndGetResponse(invalidJSON, "POST")
+
+	assertResponseHas(t, res, http.StatusBadRequest, "JSON deserialisation was not successful\n")
+}
+
+// Once DB connection is made, should test that we can fail on error states during
+// interaction with DB

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,10 @@ module github.com/gpuctl/gpuctl
 
 go 1.21.1
 
+require github.com/stretchr/testify v1.8.4
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21.1
 require github.com/stretchr/testify v1.8.4
 
 require (
+	github.com/BurntSushi/toml v1.3.2
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/gpuctl/gpuctl
 
 go 1.21.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
+github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/status/gpustatus.go
+++ b/internal/status/gpustatus.go
@@ -1,5 +1,7 @@
 package status
 
+import "errors"
+
 type GPUStatusPacket struct {
 	// Contextual information
 	Name          string `json:"gpu_name"`
@@ -8,9 +10,76 @@ type GPUStatusPacket struct {
 	MemoryTotal   uint64 `json:"memory_total"`
 
 	// Temporal statistics
-	MemoryUtilisation uint64 `json:"memory_util"` // Percentage of memory used
-	GPUUtilisation    uint64 `json:"gpu_util"`    // Percentage of memory used
-	MemoryUsed        uint64 `json:"memory_used"`
-	FanSpeed          uint64 `json:"fan_speed"` // Percentage of fan speed
-	Temp              int64  `json:"gpu_temp"`  // Celcius
+	MemoryUtilisation float64 `json:"memory_util"` // Percentage of memory used
+	GPUUtilisation    float64 `json:"gpu_util"`    // Percentage of memory used
+	MemoryUsed        float64 `json:"memory_used"`
+	FanSpeed          float64 `json:"fan_speed"` // Percentage of fan speed
+	Temp              float64 `json:"gpu_temp"`  // Celcius
+}
+
+type UncontextualGPUStatusPacket struct {
+	MemoryUtilisation float64 `json:"memory_util"`
+	GPUUtilisation    float64 `json:"gpu_util"`
+	MemoryUsed        float64 `json:"memory_used"`
+	FanSpeed          float64 `json:"fan_speed"`
+	Temp              float64 `json:"gpu_temp"`
+}
+
+// Combine two GPUStatusPacket instances into one.
+func (p GPUStatusPacket) Add(other GPUStatusPacket) (GPUStatusPacket, error) {
+	if other.Name != p.Name || other.Brand != p.Brand || other.DriverVersion != p.DriverVersion || other.MemoryTotal != p.MemoryTotal {
+		return GPUStatusPacket{}, errors.New("two packets with different contexts cannot be aggregated using Add, consider using UncontextualAdd")
+	}
+
+	return GPUStatusPacket{
+		Name:              other.Name,
+		Brand:             other.Brand,
+		DriverVersion:     other.DriverVersion,
+		MemoryTotal:       other.MemoryTotal,
+		MemoryUtilisation: p.MemoryUtilisation + other.MemoryUtilisation,
+		GPUUtilisation:    p.GPUUtilisation + other.GPUUtilisation,
+		FanSpeed:          p.FanSpeed + other.FanSpeed,
+		Temp:              p.Temp + other.Temp,
+		MemoryUsed:        p.MemoryUsed + other.MemoryUsed,
+	}, nil
+}
+
+func (p GPUStatusPacket) UncontextualAdd(other GPUStatusPacket) UncontextualGPUStatusPacket {
+	return UncontextualGPUStatusPacket{
+		MemoryUtilisation: p.MemoryUtilisation + other.MemoryUtilisation,
+		GPUUtilisation:    p.GPUUtilisation + other.GPUUtilisation,
+		FanSpeed:          p.FanSpeed + other.FanSpeed,
+		Temp:              p.Temp + other.Temp,
+		MemoryUsed:        p.MemoryUsed + other.MemoryUsed,
+	}
+}
+
+func (p GPUStatusPacket) Scale(scalar float64) GPUStatusPacket {
+	return GPUStatusPacket{
+		Name:              p.Name,
+		Brand:             p.Brand,
+		DriverVersion:     p.DriverVersion,
+		MemoryTotal:       p.MemoryTotal,
+		MemoryUtilisation: p.MemoryUtilisation * scalar,
+		GPUUtilisation:    p.GPUUtilisation * scalar,
+		FanSpeed:          p.FanSpeed * scalar,
+		Temp:              p.Temp * scalar,
+		MemoryUsed:        p.MemoryUsed * scalar,
+	}
+}
+
+// Identity returns the identity element of GPUStatusPacket for the UncontextualCombine operation.
+func Default(name string, brand string, driverVersion string, memoryTotal uint64) GPUStatusPacket {
+	return GPUStatusPacket{
+		Name:          name,
+		Brand:         brand,
+		DriverVersion: driverVersion,
+		MemoryTotal:   memoryTotal,
+
+		MemoryUtilisation: 0,
+		GPUUtilisation:    0,
+		MemoryUsed:        0,
+		FanSpeed:          0,
+		Temp:              0,
+	}
 }

--- a/internal/status/gpustatus_test.go
+++ b/internal/status/gpustatus_test.go
@@ -1,0 +1,60 @@
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdd(t *testing.T) {
+	packet1 := Default("GPU1", "BrandA", "1.0", 1024)
+	packet1.MemoryUtilisation = 50
+	packet1.GPUUtilisation = 60
+
+	packet2 := Default("GPU1", "BrandA", "1.0", 1024)
+	packet2.MemoryUtilisation = 30
+	packet2.GPUUtilisation = 40
+
+	combinedPacket, err := packet1.Add(packet2)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(80), combinedPacket.MemoryUtilisation)
+	assert.Equal(t, float64(100), combinedPacket.GPUUtilisation)
+}
+
+func TestAddFail(t *testing.T) {
+	packet1 := Default("GPU1", "BrandA", "1.0", 1024)
+	packet1.MemoryUtilisation = 50
+	packet1.GPUUtilisation = 60
+
+	packet3 := Default("GPU2", "BrandB", "2.0", 2048)
+	_, err := packet1.Add(packet3)
+	assert.Error(t, err)
+}
+
+func TestUncontextualAdd(t *testing.T) {
+	packet1 := Default("GPU1", "BrandA", "1.0", 1024)
+	packet1.MemoryUtilisation = 50
+	packet1.GPUUtilisation = 60
+
+	packet2 := Default("GPU2", "BrandB", "2.0", 2048)
+	packet2.MemoryUtilisation = 30
+	packet2.GPUUtilisation = 40
+
+	uncontextualSum := packet1.UncontextualAdd(packet2)
+	assert.Equal(t, float64(80), uncontextualSum.MemoryUtilisation)
+	assert.Equal(t, float64(100), uncontextualSum.GPUUtilisation)
+}
+
+func TestScale(t *testing.T) {
+	packet := Default("GPU1", "BrandA", "1.0", 1024)
+	packet.MemoryUtilisation = 50
+
+	scaledPacket := packet.Scale(2)
+	assert.Equal(t, float64(100), scaledPacket.MemoryUtilisation)
+}
+
+func TestDefault(t *testing.T) {
+	packet := Default("GPU1", "BrandA", "1.0", 1024)
+	assert.Equal(t, "GPU1", packet.Name)
+	assert.Equal(t, float64(0), packet.MemoryUtilisation)
+}


### PR DESCRIPTION
**Currently in the process of being drafted, PR has been opened to welcome comments.**

See [this issue](https://github.com/gpuctl/gpuctl/issues/23). 

PR introduces a handler for the `/api/remote` endpoint. Handler is somewhat thin with two minor roles: deserialise the incoming data, and hand-off the data to the database engine (stubbed out at the moment while waiting on #26).  Test suite tests both side-effect free construction, and expected happy and failure states for HTTP-based communication. 

PR also introduces a suggestion for a restricted aggregation model for the data for in-process aggregation. This has involved tweaking the `GPUStatusPacket` struct to support floats. Aggregation model is tested likewise.

PR also introduces a proof-of-concept design for binary parameterisation via a TOML file.