### PR TITLE
cmd/groundstation: Fix copylocks

### DIFF
--- a/cmd/groundstation/main.go
+++ b/cmd/groundstation/main.go
@@ -39,7 +39,7 @@ func main() {
 
 type Server struct {
 	mux *femto.Femto
-	gs  groundstation
+	gs  *groundstation
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -48,7 +48,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func NewServer() *Server {
 	mux := new(femto.Femto)
-	gs := groundstation{lastSeen: make(map[string]time.Time)}
+	gs := &groundstation{lastSeen: make(map[string]time.Time)}
 
 	/// Register routes.
 	femto.OnPost(mux, uplink.HeartbeatUrl, gs.heartbeat)


### PR DESCRIPTION
alona@Ashtabula:~/dev/gpuctl$ go vet ./...
cmd/groundstation/main.go:56:22: literal copies lock value from gs: github.com/gpuctl/gpuctl/cmd/groundstation.groundstation contains sync.Mutex
