### PR TITLE
Transmit hostname with heartbeat

### DIFF
--- a/cmd/groundstation/main.go
+++ b/cmd/groundstation/main.go
@@ -66,12 +66,13 @@ func (gs *groundstation) heartbeat(data uplink.HeartbeatReq, req *http.Request, 
 	gs.mu.Lock()
 	defer gs.mu.Unlock()
 
-	from := req.RemoteAddr
+	from := data.Hostname
 	prev := gs.lastSeen[from]
 
-	gs.lastSeen[from] = data.Time
+	now := time.Now()
+	gs.lastSeen[from] = now
 
-	log.Info("Received a heartbeat", "prev_time", prev, "cur_time", data.Time)
+	log.Info("Received a heartbeat", "satellite", from, "prev_time", prev, "cur_time", now)
 
 	return nil
 }

--- a/cmd/satellite/main.go
+++ b/cmd/satellite/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/gpuctl/gpuctl/internal/femto"
@@ -12,9 +13,17 @@ func main() {
 
 	log := slog.Default()
 
+	host, err := os.Hostname()
+	if err != nil {
+		log.Error("failed to get hostname", "err", err)
+		return
+	}
+
 	s := satellite{
 		// TODO: Make this configurable
 		gsAddr: "http://localhost:8080",
+		// we assume hostnames don't change during the program's runtime
+		hostname: host,
 	}
 
 	log.Info("Starting satellite")
@@ -32,12 +41,13 @@ func main() {
 }
 
 type satellite struct {
-	gsAddr string
+	hostname string
+	gsAddr   string
 }
 
 func (s *satellite) sendHeartBeat() error {
 	return femto.Post(
 		s.gsAddr+uplink.HeartbeatUrl,
-		uplink.HeartbeatReq{Time: time.Now()},
+		uplink.HeartbeatReq{Hostname: s.hostname},
 	)
 }

--- a/internal/uplink/heartbeat.go
+++ b/internal/uplink/heartbeat.go
@@ -2,10 +2,8 @@
 
 package uplink
 
-import "time"
-
 const HeartbeatUrl = "/gs-api/heartbeat/"
 
 type HeartbeatReq struct {
-	Time time.Time
+	Hostname string
 }


### PR DESCRIPTION
We need to be able to recognise machines when they send us their heartbeats and don't want to rely on IP addresses.

Also whilst modifying heart, stop sending the satellite time with the heartbeat, which closes #33