### PR TITLE
Add satellite -> groundstation messaging

### DIFF
--- a/cmd/groundstation/main.go
+++ b/cmd/groundstation/main.go
@@ -14,7 +14,6 @@ import (
 )
 
 func main() {
-	slog.Info("Starting groundstation")
 
 	configuration, err := config.GetConfiguration("config.toml")
 
@@ -24,8 +23,10 @@ func main() {
 		return
 	}
 
+	slog.Info("Stating groundstation", "port", configuration.Server.Port)
+
 	// TODO: Move this into fempto.
-	http.HandleFunc("/api/remote", remote.HandleStatusSubmission)
+	http.HandleFunc(uplink.StatusSubmissionUrl, remote.HandleStatusSubmission)
 	http.ListenAndServe(config.PortToAddress(configuration.Server.Port), nil)
 
 	srv := NewServer()

--- a/cmd/groundstation/remote/remote.go
+++ b/cmd/groundstation/remote/remote.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 
 	"github.com/gpuctl/gpuctl/internal/status"
@@ -20,6 +21,7 @@ func buildStatusObject(jsonData []byte) (status.GPUStatusPacket, error) {
 }
 
 func handleGPUStatusObject(stat status.GPUStatusPacket) error {
+	slog.Info("Received packet", "packet", stat)
 	return nil
 }
 
@@ -29,7 +31,6 @@ func HandleStatusSubmission(writer http.ResponseWriter, request *http.Request) {
 			writer, "Invalid method for status submission",
 			http.StatusBadRequest,
 		)
-
 		return
 	}
 
@@ -66,7 +67,6 @@ func HandleStatusSubmission(writer http.ResponseWriter, request *http.Request) {
 
 		return
 	}
-
 	writer.WriteHeader(http.StatusOK)
 	writer.Write([]byte("OK: Submission processed successfully"))
 }

--- a/internal/status/handlers/nvidia.go
+++ b/internal/status/handlers/nvidia.go
@@ -356,7 +356,7 @@ func GetNvidiaGPUStatus() (NvidiaSmiLog, error) {
 type NvidiaGPUHandler struct{}
 
 // Run the whole pipeline of getting GPU information
-func (h *NvidiaGPUHandler) GetGPUStatus() (status.GPUStatusPacket, error) {
+func (h NvidiaGPUHandler) GetGPUStatus() (status.GPUStatusPacket, error) {
 	smi, err := GetNvidiaGPUStatus()
 	if err != nil {
 		return status.GPUStatusPacket{}, err

--- a/internal/uplink/status.go
+++ b/internal/uplink/status.go
@@ -1,0 +1,3 @@
+package uplink
+
+const StatusSubmissionUrl = "/gs-api/status/"


### PR DESCRIPTION
Simple enough. Just added so we can have some way of testing the whole pipeline (satellite -> groundstation -> api -> user) soon.