### PR TITLE
cmd/groundstation: Use femto for status submission.

### DIFF
--- a/cmd/groundstation/gsapi/server.go
+++ b/cmd/groundstation/gsapi/server.go
@@ -1,0 +1,55 @@
+// package gsapi implements the groundstation API, that satellites talk to.
+
+package gsapi
+
+import (
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gpuctl/gpuctl/cmd/groundstation/remote"
+	"github.com/gpuctl/gpuctl/internal/femto"
+	"github.com/gpuctl/gpuctl/internal/uplink"
+)
+
+type Server struct {
+	mux *femto.Femto
+	gs  *groundstation
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+func NewServer() *Server {
+	mux := new(femto.Femto)
+	gs := &groundstation{lastSeen: make(map[string]time.Time)}
+
+	/// Register routes.
+	femto.OnPost(mux, uplink.HeartbeatUrl, gs.heartbeat)
+	femto.OnPost(mux, "/api/status/", remote.HandleStatusSubmission)
+
+	return &Server{mux, gs}
+}
+
+type groundstation struct {
+	lastSeen map[string]time.Time
+	mu       sync.Mutex
+}
+
+func (gs *groundstation) heartbeat(data uplink.HeartbeatReq, req *http.Request, log *slog.Logger) error {
+	// TODO: Pull out just the IP here.
+	gs.mu.Lock()
+	defer gs.mu.Unlock()
+
+	from := data.Hostname
+	prev := gs.lastSeen[from]
+
+	now := time.Now()
+	gs.lastSeen[from] = now
+
+	log.Info("Received a heartbeat", "satellite", from, "prev_time", prev, "cur_time", now)
+
+	return nil
+}

--- a/cmd/groundstation/gsapi/server_test.go
+++ b/cmd/groundstation/gsapi/server_test.go
@@ -1,4 +1,4 @@
-package main_test
+package gsapi_test
 
 import (
 	"bytes"
@@ -7,14 +7,14 @@ import (
 	"sync"
 	"testing"
 
-	gs "github.com/gpuctl/gpuctl/cmd/groundstation"
+	"github.com/gpuctl/gpuctl/cmd/groundstation/gsapi"
 	"github.com/gpuctl/gpuctl/internal/uplink"
 )
 
 func TestHeartbeatRace(t *testing.T) {
 	t.Parallel()
 
-	srv := gs.NewServer()
+	srv := gsapi.NewServer()
 	var wg sync.WaitGroup
 
 	toSpawn := 100

--- a/cmd/groundstation/main.go
+++ b/cmd/groundstation/main.go
@@ -1,79 +1,28 @@
 package main
 
 import (
-	"fmt"
 	"log/slog"
 	"net/http"
-	"sync"
-	"time"
 
 	"github.com/gpuctl/gpuctl/cmd/groundstation/config"
-	"github.com/gpuctl/gpuctl/cmd/groundstation/remote"
-	"github.com/gpuctl/gpuctl/internal/femto"
-	"github.com/gpuctl/gpuctl/internal/uplink"
+	"github.com/gpuctl/gpuctl/cmd/groundstation/gsapi"
 )
 
 func main() {
+	slog.Info("Starting groundstation")
 
 	configuration, err := config.GetConfiguration("config.toml")
 
 	if err != nil {
-		// TODO: Using logging library for auditing, fail soft
-		fmt.Println("Error detected when determining configuration")
+		slog.Error("failed to load config, shutting down", "err", err)
 		return
 	}
 
-	slog.Info("Stating groundstation", "port", configuration.Server.Port)
+	srv := gsapi.NewServer()
 
-	// TODO: Move this into fempto.
-	http.HandleFunc(uplink.StatusSubmissionUrl, remote.HandleStatusSubmission)
-	http.ListenAndServe(config.PortToAddress(configuration.Server.Port), nil)
+	slog.Info("Stating groundstation API server", "port", configuration.Server.Port)
 
-	srv := NewServer()
+	err = http.ListenAndServe(config.PortToAddress(configuration.Server.Port), srv)
 
-	http.ListenAndServe(":8080", srv)
-
-	// TODO: Make this configurable
-	// err = mux.ListenAndServe(":8080")
 	slog.Info("Shut down groundstation", "err", err)
-}
-
-type Server struct {
-	mux *femto.Femto
-	gs  *groundstation
-}
-
-func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.mux.ServeHTTP(w, r)
-}
-
-func NewServer() *Server {
-	mux := new(femto.Femto)
-	gs := &groundstation{lastSeen: make(map[string]time.Time)}
-
-	/// Register routes.
-	femto.OnPost(mux, uplink.HeartbeatUrl, gs.heartbeat)
-
-	return &Server{mux, gs}
-}
-
-type groundstation struct {
-	lastSeen map[string]time.Time
-	mu       sync.Mutex
-}
-
-func (gs *groundstation) heartbeat(data uplink.HeartbeatReq, req *http.Request, log *slog.Logger) error {
-	// TODO: Pull out just the IP here.
-	gs.mu.Lock()
-	defer gs.mu.Unlock()
-
-	from := data.Hostname
-	prev := gs.lastSeen[from]
-
-	now := time.Now()
-	gs.lastSeen[from] = now
-
-	log.Info("Received a heartbeat", "satellite", from, "prev_time", prev, "cur_time", now)
-
-	return nil
 }

--- a/cmd/groundstation/remote/build_json_test.go
+++ b/cmd/groundstation/remote/build_json_test.go
@@ -1,0 +1,37 @@
+package remote
+
+import (
+	"testing"
+
+	"github.com/gpuctl/gpuctl/internal/status"
+	"github.com/stretchr/testify/assert"
+)
+
+/* Status Object Construction */
+
+func TestBuildStatusObject(t *testing.T) {
+	validJSON := []byte(`{"gpu_name": "Test GPU", "gpu_brand": "BrandX", "driver_ver": "1.0", "memory_total": 4096, "memory_util": 50, "gpu_util": 50, "memory_used": 2048, "fan_speed": 70, "gpu_temp": 60}`)
+	expectedPacket := status.GPUStatusPacket{
+		Name:              "Test GPU",
+		Brand:             "BrandX",
+		DriverVersion:     "1.0",
+		MemoryTotal:       4096,
+		MemoryUtilisation: 50,
+		GPUUtilisation:    50,
+		MemoryUsed:        2048,
+		FanSpeed:          70,
+		Temp:              60,
+	}
+
+	packet, err := buildStatusObject(validJSON)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedPacket, packet)
+
+}
+
+func TestBuildMalformedObject(t *testing.T) {
+	invalidJSON := []byte(`{"gpu_name": "Test GPU", "gpu_brand": "BrandX", "driver_ver": 1.0}`)
+	_, err := buildStatusObject(invalidJSON)
+
+	assert.Error(t, err)
+}

--- a/cmd/groundstation/remote/remote.go
+++ b/cmd/groundstation/remote/remote.go
@@ -2,13 +2,13 @@ package remote
 
 import (
 	"encoding/json"
-	"io"
 	"log/slog"
 	"net/http"
 
 	"github.com/gpuctl/gpuctl/internal/status"
 )
 
+// TODO: Remove this
 func buildStatusObject(jsonData []byte) (status.GPUStatusPacket, error) {
 	var handler status.GPUStatusPacket
 
@@ -25,48 +25,12 @@ func handleGPUStatusObject(stat status.GPUStatusPacket) error {
 	return nil
 }
 
-func HandleStatusSubmission(writer http.ResponseWriter, request *http.Request) {
-	if request.Method != "POST" {
-		http.Error(
-			writer, "Invalid method for status submission",
-			http.StatusBadRequest,
-		)
-		return
-	}
-
-	body, err := io.ReadAll(request.Body)
-	defer request.Body.Close()
+func HandleStatusSubmission(packet status.GPUStatusPacket, req *http.Request, log *slog.Logger) error {
+	err := handleGPUStatusObject(packet)
 
 	if err != nil {
-		http.Error(
-			writer, "Malformed request body detected",
-			http.StatusBadRequest,
-		)
-
-		return
+		return err
 	}
 
-	packet, err := buildStatusObject(body)
-
-	if err != nil {
-		http.Error(
-			writer, "JSON deserialisation was not successful",
-			http.StatusBadRequest,
-		)
-
-		return
-	}
-
-	err = handleGPUStatusObject(packet)
-
-	if err != nil {
-		http.Error(
-			writer, "There was an error while handling the status object",
-			http.StatusInternalServerError,
-		)
-
-		return
-	}
-	writer.WriteHeader(http.StatusOK)
-	writer.Write([]byte("OK: Submission processed successfully"))
+	return nil
 }


### PR DESCRIPTION
This allows removing JSON and HTTP method logic from the `HandleStatusSubmission` function.

It also means all the methods are on the same mux.

Doing this requires moving the API stuff into it's own library, so it can be tested nicely. We'll also want this for when the web api, and ground API are on the same binary.
