### PR TITLE
Annotating parallel on tests

### DIFF
--- a/cmd/groundstation/config/config_test.go
+++ b/cmd/groundstation/config/config_test.go
@@ -37,6 +37,7 @@ func createTempConfigFile(content string, t *testing.T) (string, func()) {
 }
 
 func TestFileEmpty_EmptyCase(t *testing.T) {
+	t.Parallel()
 	content := ``
 
 	filename, cleanup := createTempConfigFile(content, t)
@@ -49,6 +50,7 @@ func TestFileEmpty_EmptyCase(t *testing.T) {
 }
 
 func TestFileEmpty_NonEmptyCase(t *testing.T) {
+	t.Parallel()
 	content := `see, it's not empty :)`
 
 	filename, cleanup := createTempConfigFile(content, t)
@@ -61,12 +63,14 @@ func TestFileEmpty_NonEmptyCase(t *testing.T) {
 }
 
 func TestFileEmpty_InvalidCase(t *testing.T) {
+	t.Parallel()
 	_, err := IsFileEmpty("dummy_path")
 
 	assert.Error(t, err)
 }
 
 func TestGetConfiguration_ValidConfig(t *testing.T) {
+	t.Parallel()
 	content := `
 [server]
 port = 9090`
@@ -81,6 +85,7 @@ port = 9090`
 }
 
 func TestGetConfiguration_DefaultConfig(t *testing.T) {
+	t.Parallel()
 	content := ``
 
 	filename, cleanup := createTempConfigFile(content, t)
@@ -94,6 +99,7 @@ func TestGetConfiguration_DefaultConfig(t *testing.T) {
 }
 
 func TestGetConfiguration_InvalidConfig(t *testing.T) {
+	t.Parallel()
 	content := `
 server: "should be a table, not a string"`
 	filename, cleanup := createTempConfigFile(content, t)
@@ -107,5 +113,6 @@ server: "should be a table, not a string"`
 }
 
 func TestPortToAddress(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, ":9090", PortToAddress(9090))
 }

--- a/internal/gpustats/gpustatus_test.go
+++ b/internal/gpustats/gpustatus_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestAdd(t *testing.T) {
+	t.Parallel()
 	packet1 := gpustats.Default("GPU1", "BrandA", "1.0", 1024)
 	packet1.MemoryUtilisation = 50
 	packet1.GPUUtilisation = 60
@@ -23,6 +24,7 @@ func TestAdd(t *testing.T) {
 }
 
 func TestAddFail(t *testing.T) {
+	t.Parallel()
 	packet1 := gpustats.Default("GPU1", "BrandA", "1.0", 1024)
 	packet1.MemoryUtilisation = 50
 	packet1.GPUUtilisation = 60
@@ -33,6 +35,7 @@ func TestAddFail(t *testing.T) {
 }
 
 func TestUncontextualAdd(t *testing.T) {
+	t.Parallel()
 	packet1 := gpustats.Default("GPU1", "BrandA", "1.0", 1024)
 	packet1.MemoryUtilisation = 50
 	packet1.GPUUtilisation = 60
@@ -47,6 +50,7 @@ func TestUncontextualAdd(t *testing.T) {
 }
 
 func TestScale(t *testing.T) {
+	t.Parallel()
 	packet := gpustats.Default("GPU1", "BrandA", "1.0", 1024)
 	packet.MemoryUtilisation = 50
 
@@ -55,6 +59,7 @@ func TestScale(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
+	t.Parallel()
 	packet := gpustats.Default("GPU1", "BrandA", "1.0", 1024)
 	assert.Equal(t, "GPU1", packet.Name)
 	assert.Equal(t, float64(0), packet.MemoryUtilisation)

--- a/internal/gpustats/nvidia_test.go
+++ b/internal/gpustats/nvidia_test.go
@@ -18,6 +18,7 @@ const (
 )
 
 func TestNvidiaSmiXMLParsing(t *testing.T) {
+	t.Parallel()
 	files, err := os.ReadDir(testDataRoot)
 	if err != nil {
 		t.Fatalf("Could not read test data root: %v", err)
@@ -71,6 +72,7 @@ func TestNvidiaSmiXMLParsing(t *testing.T) {
 }
 
 func TestNvidiaSmiFaultyInput(t *testing.T) {
+	t.Parallel()
 	files, err := os.ReadDir(testDataRoot)
 	if err != nil {
 		t.Fatalf("Could not read test data root: %v", err)
@@ -95,6 +97,7 @@ func TestNvidiaSmiFaultyInput(t *testing.T) {
 }
 
 func TestNvidiaSmiInvalidDataParse(t *testing.T) {
+	t.Parallel()
 	files, err := os.ReadDir(testDataRoot)
 	if err != nil {
 		t.Fatalf("Could not read test data root: %v", err)

--- a/internal/groundstation/control.go
+++ b/internal/groundstation/control.go
@@ -1,0 +1,1 @@
+package groundstation

--- a/internal/groundstation/gpustatus_test.go
+++ b/internal/groundstation/gpustatus_test.go
@@ -59,6 +59,7 @@ func assertResponseHas(t *testing.T, res *http.Response, expectedStatusCode int,
 }
 
 func TestHandleStatusSubmission(t *testing.T) {
+	t.Parallel()
 	validJSON := []byte(`{"gpu_name": "Test GPU", "gpu_brand": "BrandX", "driver_ver": "1.0", "memory_total": 4096, "memory_util": 50, "gpu_util": 50, "memory_used": 2048, "fan_speed": 70, "gpu_temp": 60}`)
 
 	res := simulateSubmissionAndGetResponse(validJSON, "POST")
@@ -67,6 +68,7 @@ func TestHandleStatusSubmission(t *testing.T) {
 }
 
 func TestHandleWrongMethodSubmission(t *testing.T) {
+	t.Parallel()
 	validJSON := []byte(`{"gpu_name": "Test GPU", "gpu_brand": "BrandX", "driver_ver": "1.0", "memory_total": 4096, "memory_util": 50, "gpu_util": 50, "memory_used": 2048, "fan_speed": 70, "gpu_temp": 60}`)
 
 	res := simulateSubmissionAndGetResponse(validJSON, "GET")
@@ -75,12 +77,14 @@ func TestHandleWrongMethodSubmission(t *testing.T) {
 }
 
 func TestHandleBadJsonSubmission(t *testing.T) {
+	t.Parallel()
 	res := simulateCorruptedSubmissionAndGetResponse("POST")
 
 	assertResponseHas(t, res, http.StatusBadRequest, "Read corrupted\n")
 }
 
 func TestHandleBadJsonDeserialisation(t *testing.T) {
+	t.Parallel()
 	invalidJSON := []byte(`{"gpu_name": "Test GPU", "gpu_brand": "BrandX", "driver_ver": 1.0}`)
 
 	res := simulateSubmissionAndGetResponse(invalidJSON, "POST")


### PR DESCRIPTION
Simple PR! Annotating tests with `t.Parallel()` to improve execution speeds.