### PR TITLE
webapi: Use `femto`

### DIFF
--- a/cmd/webapi/main.go
+++ b/cmd/webapi/main.go
@@ -1,36 +1,16 @@
 package main
 
 import (
-	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
+
+	"github.com/gpuctl/gpuctl/internal/webapi"
 )
 
-const ALL_STATS string = `[{"name":"Shared","workStations":[{"name":"Workstation 1","gpus":[{"gpu_name":"NVIDIA GeForce GT 1030","gpu_brand":"GeForce","driver_ver":"535.146.02","memory_total":2048,"memory_util":0,"gpu_util":0,"memory_used":82,"fan_speed":35,"gpu_temp":31}]},{"name":"Workstation 2","gpus":[{"gpu_name":"NVIDIA TITAN Xp","gpu_brand":"Titan","driver_ver":"535.146.02","memory_total":12288,"memory_util":0,"gpu_util":0,"memory_used":83,"fan_speed":23,"gpu_temp":32},{"gpu_name":"NVIDIA TITAN Xp","gpu_brand":"Titan","driver_ver":"535.146.02","memory_total":12288,"memory_util":0,"gpu_util":0,"memory_used":83,"fan_speed":23,"gpu_temp":32}]},{"name":"Workstation 3","gpus":[{"gpu_name":"NVIDIA GeForce GT 730","gpu_brand":"GeForce","driver_ver":"470.223.02","memory_total":2001,"memory_util":0,"gpu_util":0,"memory_used":220,"fan_speed":30,"gpu_temp":27}]},{"name":"Workstation 5","gpus":[{"gpu_name":"NVIDIA TITAN Xp","gpu_brand":"Titan","driver_ver":"535.146.02","memory_total":12288,"memory_util":0,"gpu_util":0,"memory_used":83,"fan_speed":23,"gpu_temp":32},{"gpu_name":"NVIDIA TITAN Xp","gpu_brand":"Titan","driver_ver":"535.146.02","memory_total":12288,"memory_util":0,"gpu_util":0,"memory_used":83,"fan_speed":23,"gpu_temp":32}]},{"name":"Workstation 4","gpus":[{"gpu_name":"NVIDIA GeForce GT 1030","gpu_brand":"GeForce","driver_ver":"535.146.02","memory_total":2048,"memory_util":0,"gpu_util":0,"memory_used":82,"fan_speed":35,"gpu_temp":31}]},{"name":"Workstation 6","gpus":[{"gpu_name":"NVIDIA GeForce GT 730","gpu_brand":"GeForce","driver_ver":"470.223.02","memory_total":2001,"memory_util":0,"gpu_util":0,"memory_used":220,"fan_speed":30,"gpu_temp":27}]}]}]`
-
-const API_URL string = "localhost:8000"
-
 func main() {
-	init_server()
-	for {
-		// Loop
-	}
-}
+	slog.Info("Starting webapi")
 
-func init_server() {
-	fmt.Println("API is starting up!")
-	http.HandleFunc("/", handler)
-	log.Fatal(http.ListenAndServe(API_URL, nil))
-}
+	srv := webapi.NewServer()
 
-func handler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	switch r.URL.Path {
-	case "/api/stats/all":
-		fmt.Fprint(w, ALL_STATS)
-	default:
-		{
-
-		}
-	}
+	http.ListenAndServe(":8000", srv)
 }

--- a/frontend/src/Data.tsx
+++ b/frontend/src/Data.tsx
@@ -1,5 +1,9 @@
+
+// These types need to be kept in sync with `internal/webapi/types.go`
+
 export type WorkStationGroup = {
   name: string;
+  // TODO: Consistant cases here
   workStations: WorkStationData[];
 };
 
@@ -8,6 +12,7 @@ export type WorkStationData = {
   gpus: GPUStats[];
 };
 
+// This needs to be kept in sync with `internal/uplink/
 export type GPUStats = {
   gpu_name: string;
   gpu_brand: string;

--- a/internal/webapi/server.go
+++ b/internal/webapi/server.go
@@ -1,0 +1,1 @@
+package webapi

--- a/internal/webapi/server.go
+++ b/internal/webapi/server.go
@@ -1,1 +1,72 @@
 package webapi
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/gpuctl/gpuctl/internal/femto"
+	"github.com/gpuctl/gpuctl/internal/uplink"
+)
+
+type Server struct {
+	mux *femto.Femto
+	api *api
+}
+
+type api struct {
+	// ???
+}
+
+func NewServer() *Server {
+	mux := new(femto.Femto)
+	api := &api{}
+
+	femto.OnGet[workstations](mux, "/api/stats/all", api.allstats)
+
+	return &Server{mux, api}
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+var dummyData workstations = workstations{
+	workstationGroup{
+		Name: "Shared", WorkStations: []workStationData{
+			{
+				Name: "Workstation 1", Gpus: []uplink.GPUStats{
+					{Name: "NVIDIA GeForce GT 1030", Brand: "GeForce", DriverVersion: "535.146.02", MemoryTotal: 0x800, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 82, FanSpeed: 35, Temp: 31},
+				},
+			},
+			{
+				Name: "Workstation 2", Gpus: []uplink.GPUStats{
+					{Name: "NVIDIA TITAN Xp", Brand: "Titan", DriverVersion: "535.146.02", MemoryTotal: 0x3000, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 83, FanSpeed: 23, Temp: 32},
+					{Name: "NVIDIA TITAN Xp", Brand: "Titan", DriverVersion: "535.146.02", MemoryTotal: 0x3000, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 83, FanSpeed: 23, Temp: 32},
+				},
+			},
+			{
+				Name: "Workstation 3", Gpus: []uplink.GPUStats{
+					{Name: "NVIDIA GeForce GT 730", Brand: "GeForce", DriverVersion: "470.223.02", MemoryTotal: 0x7d1, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 220, FanSpeed: 30, Temp: 27},
+				},
+			},
+			{
+				Name: "Workstation 5", Gpus: []uplink.GPUStats{
+					{Name: "NVIDIA TITAN Xp", Brand: "Titan", DriverVersion: "535.146.02", MemoryTotal: 0x3000, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 83, FanSpeed: 23, Temp: 32},
+					{Name: "NVIDIA TITAN Xp", Brand: "Titan", DriverVersion: "535.146.02", MemoryTotal: 0x3000, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 83, FanSpeed: 23, Temp: 32},
+				},
+			},
+			{
+				Name: "Workstation 4", Gpus: []uplink.GPUStats{
+					{Name: "NVIDIA GeForce GT 1030", Brand: "GeForce", DriverVersion: "535.146.02", MemoryTotal: 0x800, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 82, FanSpeed: 35, Temp: 31},
+				},
+			},
+			{
+				Name: "Workstation 6", Gpus: []uplink.GPUStats{
+					{Name: "NVIDIA GeForce GT 730", Brand: "GeForce", DriverVersion: "470.223.02", MemoryTotal: 0x7d1, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 220, FanSpeed: 30, Temp: 27},
+				},
+			},
+		}}}
+
+func (a *api) allstats(r *http.Request, l *slog.Logger) (workstations, error) {
+	return dummyData, nil
+}

--- a/internal/webapi/types.go
+++ b/internal/webapi/types.go
@@ -1,0 +1,19 @@
+package webapi
+
+import (
+	"github.com/gpuctl/gpuctl/internal/uplink"
+)
+
+// These types need to be kept in sync with `frontend/src/Data.tsx`
+
+type workstations []workstationGroup
+
+type workstationGroup struct {
+	Name         string            `json:"name"`
+	WorkStations []workStationData `json:"workStations"`
+}
+
+type workStationData struct {
+	Name string            `json:"name"`
+	Gpus []uplink.GPUStats `json:"gpus"`
+}

--- a/internal/webapi/types_test.go
+++ b/internal/webapi/types_test.go
@@ -1,0 +1,63 @@
+package webapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gpuctl/gpuctl/internal/uplink"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshal(t *testing.T) {
+	t.Parallel()
+
+	var data workstations
+
+	jsonRep := `[{"name":"Shared","workStations":[{"name":"Workstation 1","gpus":[{"gpu_name":"NVIDIA GeForce GT 1030","gpu_brand":"GeForce","driver_ver":"535.146.02","memory_total":2048,"memory_util":0,"gpu_util":0,"memory_used":82,"fan_speed":35,"gpu_temp":31}]},{"name":"Workstation 2","gpus":[{"gpu_name":"NVIDIA TITAN Xp","gpu_brand":"Titan","driver_ver":"535.146.02","memory_total":12288,"memory_util":0,"gpu_util":0,"memory_used":83,"fan_speed":23,"gpu_temp":32},{"gpu_name":"NVIDIA TITAN Xp","gpu_brand":"Titan","driver_ver":"535.146.02","memory_total":12288,"memory_util":0,"gpu_util":0,"memory_used":83,"fan_speed":23,"gpu_temp":32}]},{"name":"Workstation 3","gpus":[{"gpu_name":"NVIDIA GeForce GT 730","gpu_brand":"GeForce","driver_ver":"470.223.02","memory_total":2001,"memory_util":0,"gpu_util":0,"memory_used":220,"fan_speed":30,"gpu_temp":27}]},{"name":"Workstation 5","gpus":[{"gpu_name":"NVIDIA TITAN Xp","gpu_brand":"Titan","driver_ver":"535.146.02","memory_total":12288,"memory_util":0,"gpu_util":0,"memory_used":83,"fan_speed":23,"gpu_temp":32},{"gpu_name":"NVIDIA TITAN Xp","gpu_brand":"Titan","driver_ver":"535.146.02","memory_total":12288,"memory_util":0,"gpu_util":0,"memory_used":83,"fan_speed":23,"gpu_temp":32}]},{"name":"Workstation 4","gpus":[{"gpu_name":"NVIDIA GeForce GT 1030","gpu_brand":"GeForce","driver_ver":"535.146.02","memory_total":2048,"memory_util":0,"gpu_util":0,"memory_used":82,"fan_speed":35,"gpu_temp":31}]},{"name":"Workstation 6","gpus":[{"gpu_name":"NVIDIA GeForce GT 730","gpu_brand":"GeForce","driver_ver":"470.223.02","memory_total":2001,"memory_util":0,"gpu_util":0,"memory_used":220,"fan_speed":30,"gpu_temp":27}]}]}]`
+
+	err := json.Unmarshal([]byte(jsonRep), &data)
+
+	assert.NoError(t, err)
+
+	assert.Equal(
+		t,
+
+		workstations(workstations{
+			workstationGroup{
+				Name: "Shared", WorkStations: []workStationData{
+					{
+						Name: "Workstation 1", Gpus: []uplink.GPUStats{
+							{Name: "NVIDIA GeForce GT 1030", Brand: "GeForce", DriverVersion: "535.146.02", MemoryTotal: 0x800, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 82, FanSpeed: 35, Temp: 31},
+						},
+					},
+					{
+						Name: "Workstation 2", Gpus: []uplink.GPUStats{
+							{Name: "NVIDIA TITAN Xp", Brand: "Titan", DriverVersion: "535.146.02", MemoryTotal: 0x3000, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 83, FanSpeed: 23, Temp: 32},
+							{Name: "NVIDIA TITAN Xp", Brand: "Titan", DriverVersion: "535.146.02", MemoryTotal: 0x3000, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 83, FanSpeed: 23, Temp: 32},
+						},
+					},
+					{
+						Name: "Workstation 3", Gpus: []uplink.GPUStats{
+							{Name: "NVIDIA GeForce GT 730", Brand: "GeForce", DriverVersion: "470.223.02", MemoryTotal: 0x7d1, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 220, FanSpeed: 30, Temp: 27},
+						},
+					},
+					{
+						Name: "Workstation 5", Gpus: []uplink.GPUStats{
+							{Name: "NVIDIA TITAN Xp", Brand: "Titan", DriverVersion: "535.146.02", MemoryTotal: 0x3000, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 83, FanSpeed: 23, Temp: 32},
+							{Name: "NVIDIA TITAN Xp", Brand: "Titan", DriverVersion: "535.146.02", MemoryTotal: 0x3000, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 83, FanSpeed: 23, Temp: 32},
+						},
+					},
+					{
+						Name: "Workstation 4", Gpus: []uplink.GPUStats{
+							{Name: "NVIDIA GeForce GT 1030", Brand: "GeForce", DriverVersion: "535.146.02", MemoryTotal: 0x800, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 82, FanSpeed: 35, Temp: 31},
+						},
+					},
+					{
+						Name: "Workstation 6", Gpus: []uplink.GPUStats{
+							{Name: "NVIDIA GeForce GT 730", Brand: "GeForce", DriverVersion: "470.223.02", MemoryTotal: 0x7d1, MemoryUtilisation: 0, GPUUtilisation: 0, MemoryUsed: 220, FanSpeed: 30, Temp: 27},
+						},
+					},
+				}}}),
+		data,
+	)
+}


### PR DESCRIPTION
This moves the webapi into it's own module implementing `http.Handler`. It also uses the `femto` framework to abstract away routing and JSON reponces.

Makes no change to the logic itself, but makes it possible to implement those.