### PR TITLE
Remove `act` call from JarJar hook

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -55,7 +55,7 @@ test("retrieves data from API server and displays correctly", async () => {
 
         screen
           .getAllByText(gpu.gpu_temp + " °C", { exact: false })
-          .forEach((temp) => expect(temp).toBeInTheDocument());
+          .forEach((gpu_temp) => expect(gpu_temp).toBeInTheDocument());
       });
     });
   });
@@ -73,7 +73,12 @@ test("data is fetched again after refresh interval", async () => {
   (await screen.findAllByText("31 °C", { exact: false })).forEach((temp) =>
     expect(temp).toBeInTheDocument(),
   );
-  data[0].workStations[0].gpus[0].gpu_temp = 100;
+
+  const group = data[0];
+  const workStation = group.workStations[0];
+  const gpu = workStation.gpus[0];
+  gpu.gpu_temp = 100;
+
   jest.advanceTimersByTime(REFRESH_INTERVAL + 1);
 
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
@@ -82,8 +87,8 @@ test("data is fetched again after refresh interval", async () => {
   // to rerender after every fetch (just in case)
   view.rerender(<App />);
 
-  const new_temp = await screen.findByText("100 °C", { exact: false });
-  expect(new_temp).toBeInTheDocument();
+  const new_gpu_temp = await screen.findByText("100 °C", { exact: false });
+  expect(new_gpu_temp).toBeInTheDocument();
 });
 
 const mockFetch = (s: WorkStationGroup[]) => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,13 +2,15 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { default as App, REFRESH_INTERVAL } from "./App";
 import { EXAMPLE_DATA_1, WorkStationGroup } from "./Data";
 
-test("renders welcome message", () => {
+test("renders welcome message", async () => {
   mockFetch(EXAMPLE_DATA_1);
   jest.useFakeTimers();
 
   render(<App />);
-  const welcome = screen.getByText("Welcome to the GPU Control Room!");
+  const welcome = await screen.findByText("Welcome to the GPU Control Room!");
   expect(welcome).toBeInTheDocument();
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
 });
 
 test(`before fetch succeeds inform the user that data is being fetched
@@ -18,10 +20,16 @@ after fetch succeeds, no longer show that message`, async () => {
 
   render(<App />);
 
-  const statuses = screen.getAllByText("Retrieving data from API server...");
+  const statuses = await screen.findAllByText(
+    "Retrieving data from API server..."
+  );
   statuses.forEach((status) => expect(status).toBeInTheDocument());
 
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+
+  // This is janky, but I don't know a better way to wait for the state change
+  // to have occured than to wait for the results to be visible
+  await screen.findAllByText("31 °C", { exact: false });
 
   const new_status = screen.queryByText("Retrieving data from API server...");
   expect(new_status).not.toBeInTheDocument();
@@ -62,9 +70,9 @@ test("data is fetched again after refresh interval", async () => {
 
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
 
-  screen
-    .getAllByText("31 °C", { exact: false })
-    .forEach((temp) => expect(temp).toBeInTheDocument());
+  (await screen.findAllByText("31 °C", { exact: false })).forEach((temp) =>
+    expect(temp).toBeInTheDocument()
+  );
   data[0].workStations[0].gpus[0].gpu_temp = 100;
   jest.advanceTimersByTime(REFRESH_INTERVAL + 1);
 
@@ -74,7 +82,7 @@ test("data is fetched again after refresh interval", async () => {
   // to rerender after every fetch (just in case)
   view.rerender(<App />);
 
-  const new_temp = screen.getByText("100 °C", { exact: false });
+  const new_temp = await screen.findByText("100 °C", { exact: false });
   expect(new_temp).toBeInTheDocument();
 });
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -21,7 +21,7 @@ after fetch succeeds, no longer show that message`, async () => {
   render(<App />);
 
   const statuses = await screen.findAllByText(
-    "Retrieving data from API server..."
+    "Retrieving data from API server...",
   );
   statuses.forEach((status) => expect(status).toBeInTheDocument());
 
@@ -71,7 +71,7 @@ test("data is fetched again after refresh interval", async () => {
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
 
   (await screen.findAllByText("31 °C", { exact: false })).forEach((temp) =>
-    expect(temp).toBeInTheDocument()
+    expect(temp).toBeInTheDocument(),
   );
   data[0].workStations[0].gpus[0].gpu_temp = 100;
   jest.advanceTimersByTime(REFRESH_INTERVAL + 1);

--- a/frontend/src/Utils/Hooks.tsx
+++ b/frontend/src/Utils/Hooks.tsx
@@ -5,7 +5,7 @@ import { Validated, Validation, discard, loading } from "./Utils";
  * Daniel named this
  */
 export const useJarJar = <T,>(
-  f: () => Promise<Validated<T>>
+  f: () => Promise<Validated<T>>,
 ): [Validation<T>, EffectCallback] => {
   const [v, setV] = useState<Validation<T>>(loading());
   const updateV = discard(async () => {

--- a/frontend/src/Utils/Hooks.tsx
+++ b/frontend/src/Utils/Hooks.tsx
@@ -1,4 +1,3 @@
-import { act } from "@testing-library/react";
 import { EffectCallback, RefObject, useEffect, useState } from "react";
 import { Validated, Validation, discard, loading } from "./Utils";
 
@@ -6,12 +5,11 @@ import { Validated, Validation, discard, loading } from "./Utils";
  * Daniel named this
  */
 export const useJarJar = <T,>(
-  f: () => Promise<Validated<T>>,
+  f: () => Promise<Validated<T>>
 ): [Validation<T>, EffectCallback] => {
   const [v, setV] = useState<Validation<T>>(loading());
   const updateV = discard(async () => {
-    const x = await f();
-    act(() => setV(x));
+    setV(await f());
   });
 
   useOnce(updateV);


### PR DESCRIPTION
We should only ever call `act` inside tests (it is unsupported in production builds)
Unfortunately, the way I am using the state hook makes this quite challenging, so we do a janky mix of awaiting `waitFor` and `findBy`s to get Jest to stop complaining