### PR TITLE
config: Remove `Merge`.

### DIFF
--- a/internal/config/client_configuration.go
+++ b/internal/config/client_configuration.go
@@ -17,36 +17,6 @@ type SatelliteConfiguration struct {
 	Satellite     Satellite     `toml:"satellite"`
 }
 
-func (s SatelliteConfiguration) Merge(config Mergable) Mergable {
-	sat_config, ok := config.(SatelliteConfiguration)
-
-	if !ok {
-		return s
-	}
-
-	if s.Groundstation.Hostname == "" {
-		s.Groundstation.Hostname = sat_config.Groundstation.Hostname
-	}
-
-	if s.Groundstation.Port == 0 {
-		s.Groundstation.Port = sat_config.Groundstation.Port
-	}
-
-	if s.Satellite.Cache == "" {
-		s.Satellite.Cache = sat_config.Satellite.Cache
-	}
-
-	if s.Satellite.DataInterval == 0 {
-		s.Satellite.DataInterval = sat_config.Satellite.DataInterval
-	}
-
-	if s.Satellite.HeartbeatInterval == 0 {
-		s.Satellite.HeartbeatInterval = sat_config.Satellite.HeartbeatInterval
-	}
-
-	return s
-}
-
 func DefaultSatelliteConfiguration() SatelliteConfiguration {
 	return SatelliteConfiguration{
 		Groundstation: Groundstation{

--- a/internal/config/client_configuration_test.go
+++ b/internal/config/client_configuration_test.go
@@ -71,33 +71,3 @@ groundstation: "should be a table, not a string"`
 	assert.Equal(t, 0, config.Satellite.HeartbeatInterval)
 	assert.Equal(t, 0, config.Satellite.DataInterval)
 }
-
-func TestSatelliteConfigurationMerge(t *testing.T) {
-	defaultConfig := config.SatelliteConfiguration{
-		Groundstation: config.Groundstation{Hostname: "localhost", Port: 8080},
-		Satellite:     config.Satellite{Cache: "/tmp/default", DataInterval: 60, HeartbeatInterval: 10},
-	}
-
-	fileConfig := config.SatelliteConfiguration{
-		Groundstation: config.Groundstation{Hostname: "satellite.local", Port: 0},
-		Satellite:     config.Satellite{Cache: "", DataInterval: 30, HeartbeatInterval: 0},
-	}
-
-	mergedConfig := fileConfig.Merge(defaultConfig).(config.SatelliteConfiguration)
-
-	assert.Equal(t, "satellite.local", mergedConfig.Groundstation.Hostname, "Expected file config groundstation hostname to be applied")
-	assert.Equal(t, 8080, mergedConfig.Groundstation.Port, "Expected default groundstation port to be applied")
-	assert.Equal(t, "/tmp/default", mergedConfig.Satellite.Cache, "Expected default satellite cache to be applied")
-	assert.Equal(t, 30, mergedConfig.Satellite.DataInterval, "Expected file config satellite data interval to be applied")
-	assert.Equal(t, 10, mergedConfig.Satellite.HeartbeatInterval, "Expected default satellite heartbeat interval to be applied")
-}
-
-func TestSatelliteConfigurationMerge_UnhappyPath(t *testing.T) {
-	defaultConfig := config.SatelliteConfiguration{}
-
-	wrongConfig := config.ControlConfiguration{}
-
-	mergedConfig := defaultConfig.Merge(&wrongConfig)
-
-	assert.Equal(t, defaultConfig, mergedConfig, "Expected default config to be returned when wrong type is passed")
-}

--- a/internal/config/common.go
+++ b/internal/config/common.go
@@ -8,10 +8,6 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-type Mergable interface {
-	Merge(config Mergable) Mergable
-}
-
 func PortToAddress(port int) string {
 	return fmt.Sprintf(":%d", port)
 }
@@ -30,7 +26,7 @@ func IsFileEmpty(path string) (bool, error) {
 	return fileInfo.Size() == 0, nil
 }
 
-func getConfiguration[T Mergable](filename string, defaultGenerator func() T) (T, error) {
+func getConfiguration[T any](filename string, defaultGenerator func() T) (T, error) {
 	exePath, err := os.Executable()
 
 	if err != nil {

--- a/internal/config/server_configuration.go
+++ b/internal/config/server_configuration.go
@@ -16,27 +16,6 @@ type ControlConfiguration struct {
 	Database Database `toml:"database"`
 }
 
-func (s ControlConfiguration) Merge(config Mergable) Mergable {
-	sat_config, ok := config.(ControlConfiguration)
-
-	if !ok {
-		return s
-	}
-
-	if s.Database.PostgresUrl == "" {
-		s.Database.PostgresUrl = sat_config.Database.PostgresUrl
-	}
-
-	if s.Server.GSPort == 0 {
-		s.Server.GSPort = sat_config.Server.GSPort
-	}
-	if s.Server.WAPort == 0 {
-		s.Server.WAPort = sat_config.Server.WAPort
-	}
-
-	return s
-}
-
 func DefaultControlConfiguration() ControlConfiguration {
 	return ControlConfiguration{
 		Server: Server{

--- a/internal/config/server_configuration_test.go
+++ b/internal/config/server_configuration_test.go
@@ -65,31 +65,3 @@ func TestPortToAddress(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, ":9090", config.PortToAddress(9090))
 }
-
-func TestControlConfigurationMerge(t *testing.T) {
-	defaultConfig := config.ControlConfiguration{
-		Database: config.Database{PostgresUrl: "postgres://default-url"},
-		Server:   config.Server{GSPort: 8080, WAPort: 8000},
-	}
-
-	fileConfig := config.ControlConfiguration{
-		Database: config.Database{PostgresUrl: ""},
-		Server:   config.Server{GSPort: 9090, WAPort: 0},
-	}
-
-	mergedConfig := fileConfig.Merge(defaultConfig).(config.ControlConfiguration)
-
-	assert.Equal(t, "postgres://default-url", mergedConfig.Database.PostgresUrl, "Expected default database URL to be applied")
-	assert.Equal(t, 9090, mergedConfig.Server.GSPort, "Expected file config server groundstation port to be applied")
-	assert.Equal(t, 8000, mergedConfig.Server.WAPort, "Expected default config server web api port to be applied")
-}
-
-func TestControlConfigurationMerge_UnhappyPath(t *testing.T) {
-	defaultConfig := config.ControlConfiguration{}
-
-	wrongConfig := config.SatelliteConfiguration{}
-
-	mergedConfig := defaultConfig.Merge(&wrongConfig)
-
-	assert.Equal(t, defaultConfig, mergedConfig, "Expected default config to be returned when wrong type is passed")
-}


### PR DESCRIPTION
We don't use it, as `toml` does this with reflection instead. It's rather unsavory code that's easy to fall out of sync with the definitions, so it's safer to not have it if it's unused.
