### PR TITLE
ci: Ensure that `go test -short` works without postgres.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,4 +86,13 @@ jobs:
       - name: Check Frontend Formatting
         run: npm run fmt-check
         working-directory: ./frontend
-      
+
+  go-test-short:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.21.x"
+      - run: make    
+      - run: go test ./... -short


### PR DESCRIPTION
Currently, tests that relly on having a DB are skipped when `t.Short()`
is true. However, this isn't enforced by CI at all. By adding this
check, we ensure this will always be the case.
