### PR TITLE
ci: Ensure `docker-compose` build works.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,3 +96,10 @@ jobs:
           go-version: "1.21.x"
       - run: make    
       - run: go test ./... -short
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cp ./secrets/keys.example ./secrets/keys
+      - run: docker compose build

--- a/control.Dockerfile
+++ b/control.Dockerfile
@@ -6,8 +6,9 @@ RUN go mod download && go mod verify
 
 COPY cmd ./cmd
 COPY internal ./internal
+COPY Makefile Makefile
 
-RUN go build -v ./cmd/control
+RUN make control
 
 COPY control.toml.default ./control.toml
 


### PR DESCRIPTION
Currently, we don't check that the `Dockerfile`s are valid, or build in CI. We'd like to do this, so that you can't merge code that breaks docker.

Closes #90 