### PR TITLE
re-enable `assets` tests.

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -1,28 +1,28 @@
 package assets_test
 
-// import (
-// 	"bytes"
-// 	"debug/elf"
-// 	"testing"
+import (
+	"bytes"
+	"debug/elf"
+	"testing"
 
-// 	"github.com/stretchr/testify/assert"
-// 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-// 	"github.com/gpuctl/gpuctl/internal/assets"
-// )
+	"github.com/gpuctl/gpuctl/internal/assets"
+)
 
-// func TestSatelliteAmd64LinuxIsElf(t *testing.T) {
-// 	t.Parallel()
+func TestSatelliteAmd64LinuxIsElf(t *testing.T) {
+	t.Parallel()
 
-// 	reader := bytes.NewReader(assets.SatelliteAmd64Linux)
-// 	elfFile, err := elf.NewFile(reader)
-// 	require.NoError(t, err)
+	reader := bytes.NewReader(assets.SatelliteAmd64Linux)
+	elfFile, err := elf.NewFile(reader)
+	require.NoError(t, err)
 
-// 	imports, err := elfFile.ImportedLibraries()
-// 	assert.Empty(t, imports,
-// 		"satellite binary has imports, but should be static binary")
-// 	assert.NoError(t, err)
+	imports, err := elfFile.ImportedLibraries()
+	assert.Empty(t, imports,
+		"satellite binary has imports, but should be static binary")
+	assert.NoError(t, err)
 
-// 	assert.Equal(t, elf.EM_X86_64, elfFile.Machine)
-// 	assert.Equal(t, elf.ET_EXEC, elfFile.Type)
-// }
+	assert.Equal(t, elf.EM_X86_64, elfFile.Machine)
+	assert.Equal(t, elf.ET_EXEC, elfFile.Type)
+}


### PR DESCRIPTION
These were written to juice coverage numbers, but actually did catch a bug in assets, so I'd like to keep them.

If `CGO_ENABLED=0` isn't set when building `satellite-amd64-linux`, it'll depend on libc.

```
--- FAIL: TestSatelliteAmd64LinuxIsElf (0.00s)
    assets_test.go:22:
                Error Trace:    /home/alona/dev/gpuctl/internal/assets/assets_test.go:22
                Error:          Should be empty, but was [libc.so.6]
                Test:           TestSatelliteAmd64LinuxIsElf
                Messages:       satellite binary has imports, but should be static binary
FAIL
FAIL    github.com/gpuctl/gpuctl/internal/assets        0.002s
FAIL
```

For maximum likelihood of working on the remote machine, we'd like to ensure we only use the linux syscall interface instead.
