### PR TITLE
Update to go 1.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21.x"
+          go-version: "1.22.x"
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21.x"
+          go-version: "1.22.x"
       - run: make    
       - run: go test ./... -short
 

--- a/deploy/control.Dockerfile
+++ b/deploy/control.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.21
+FROM docker.io/golang:1.22
 
 WORKDIR /gpuctl
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gpuctl/gpuctl
 
-go 1.21.1
+go 1.22.0
 
 require (
 	github.com/BurntSushi/toml v1.3.2


### PR DESCRIPTION
Closes #132

Closes #80

If you have go 1.21 installed, it'll automagicly download and proxy you to the new version, so this shouldn't break anyone dev workflow: https://go.dev/blog/toolchain