### PR TITLE
Fix front-end auth

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -21,6 +21,7 @@ https://gpuctl.perial.co.uk {
 		-Access-Control-Allow-Origin
 		-Access-Control-Allow-Methods
 		-Access-Control-Allow-Headers
+		-Access-Control-Allow-Credentials
 	}
 
 	# For api routes, we can lock down the CSP even further

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -10,7 +10,7 @@ test("renders welcome message", async () => {
   const welcome = await screen.findByText("Welcome to the GPU Control Room!");
   expect(welcome).toBeInTheDocument();
 
-  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
 });
 
 test(`before fetch succeeds inform the user that data is being fetched

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,11 @@
 import "./App.css";
-import {
-  Validated,
-  failure,
-  success,
-  enumVals,
-  enumIndex,
-  isSuccess,
-} from "./Utils/Utils";
+import { enumVals, enumIndex } from "./Utils/Utils";
 import { ChakraProvider } from "@chakra-ui/react";
 import {} from "@chakra-ui/react";
-import { useState } from "react";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { MainView } from "./Pages/MainView";
 import { STATS_PATH } from "./Config/Paths";
+import { AuthProvider } from "./Providers/AuthProvider";
 
 export const API_URL =
   process.env.NODE_ENV === "production" ? "/api" : "http://localhost:8000/api";
@@ -24,27 +17,13 @@ export enum ViewPage {
   ADMIN = "/admin_view",
 }
 
-const DEFAULT_VIEW = ViewPage.CARD;
+export const DEFAULT_VIEW = ViewPage.CARD;
 
 export const VIEW_PAGE_INDEX = enumIndex(ViewPage);
 
-export type AuthToken = {
-  token: string;
-};
-
-export const AUTH_TOKEN_ITEM = "authToken";
-
-const tryGetAuthToken = (): Validated<AuthToken> => {
-  const token = localStorage.getItem(AUTH_TOKEN_ITEM);
-  return token == null ? failure(Error("No token :(")) : success({ token });
-};
-
-const App = () => {
-  const [authToken, setAuth] =
-    useState<Validated<AuthToken>>(tryGetAuthToken());
-
-  return (
-    <ChakraProvider>
+const App = () => (
+  <ChakraProvider>
+    <AuthProvider>
       <div className="App"></div>
       <BrowserRouter>
         <Routes>
@@ -57,23 +36,13 @@ const App = () => {
             <Route
               key={i}
               path={STATS_PATH + page}
-              element={
-                page === ViewPage.ADMIN && !isSuccess(authToken) ? (
-                  <Navigate to={STATS_PATH + DEFAULT_VIEW} replace />
-                ) : (
-                  <MainView
-                    authToken={authToken}
-                    setAuth={setAuth}
-                    default={page}
-                  />
-                )
-              }
+              element={<MainView page={page} />}
             />
           ))}
         </Routes>
       </BrowserRouter>
-    </ChakraProvider>
-  );
-};
+    </AuthProvider>
+  </ChakraProvider>
+);
 
 export default App;

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -16,9 +16,9 @@ import {
 import { ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { STATS_PATH } from "../Config/Paths";
-import { AuthToken, VIEW_PAGE_INDEX, ViewPage } from "../App";
+import { VIEW_PAGE_INDEX, ViewPage } from "../App";
 import { SignIn } from "./SignIn";
-import { Validated, isSuccess } from "../Utils/Utils";
+import { useAuth } from "../Providers/AuthProvider";
 
 const URLS = [
   `${STATS_PATH}/card_view`,
@@ -28,17 +28,12 @@ const URLS = [
 
 export const Navbar = ({
   children,
-  signIn,
-  signOut,
-  authToken,
   initial,
 }: {
   children: ReactNode[];
-  signIn: (tok: AuthToken) => void;
-  signOut: () => void;
-  authToken: Validated<AuthToken>;
   initial: ViewPage;
 }) => {
+  const { isSignedIn, logout } = useAuth();
   const nav = useNavigate();
 
   return (
@@ -50,10 +45,10 @@ export const Navbar = ({
       <TabList>
         <Tab>Card View</Tab>
         <Tab>Table View</Tab>
-        <Tab isDisabled={!isSuccess(authToken)}>Admin Panel</Tab>
+        <Tab isDisabled={!isSignedIn()}>Admin Panel</Tab>
         <Spacer />
-        {isSuccess(authToken) ? (
-          <Button onClick={signOut}>Sign Out</Button>
+        {isSignedIn() ? (
+          <Button onClick={logout}>Sign Out</Button>
         ) : (
           <Popover>
             <PopoverTrigger>
@@ -62,7 +57,7 @@ export const Navbar = ({
             <PopoverContent w="100%">
               <PopoverArrow />
               <PopoverCloseButton />
-              <SignIn signIn={signIn} />
+              <SignIn />
             </PopoverContent>
           </Popover>
         )}

--- a/frontend/src/Components/SignIn.tsx
+++ b/frontend/src/Components/SignIn.tsx
@@ -1,41 +1,10 @@
 import { useState } from "react";
-import { API_URL, AuthToken } from "../App";
-import { Validated, failure, success, validatedElim } from "../Utils/Utils";
-import { ADMIN_PATH } from "../Pages/AdminPanel";
 import { Box, Button, Heading, Input, VStack } from "@chakra-ui/react";
+import { useAuth } from "../Providers/AuthProvider";
 
-const AUTH_PATH = "/auth";
+export const SignIn = () => {
+  const { login } = useAuth();
 
-const DEBUG_AUTH = true;
-const DEBUG_USER = "NathanielB";
-const DEBUG_PASSWORD = "drowssap";
-const DEBUG_TOKEN = "ABCDEFG";
-
-const requestSignIn = async (
-  username: string,
-  password: string,
-): Promise<Validated<AuthToken>> => {
-  if (DEBUG_AUTH) {
-    if (username === DEBUG_USER && password === DEBUG_PASSWORD) {
-      return success({ token: DEBUG_TOKEN });
-    }
-  }
-
-  const resp = await fetch(API_URL + ADMIN_PATH + AUTH_PATH, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ username, password }),
-  });
-
-  if (resp.ok) {
-    const tok: AuthToken = await resp.json();
-    return success(tok);
-  }
-  if (resp.status === 401) return failure(Error("Unauthorised!"));
-  return failure(Error("Authentication Failed for an Unknown Reason!"));
-};
-
-export const SignIn = ({ signIn }: { signIn: (tok: AuthToken) => void }) => {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
 
@@ -67,14 +36,7 @@ export const SignIn = ({ signIn }: { signIn: (tok: AuthToken) => void }) => {
         <Button
           bgColor={"white"}
           onClick={async () => {
-            const tok = await requestSignIn(username, password);
-            validatedElim(tok, {
-              success: (t) => {
-                signIn(t);
-                window.location.reload();
-              },
-              failure: () => {},
-            });
+            login(username, password);
           }}
         >
           Sign In

--- a/frontend/src/Pages/AdminPanel.tsx
+++ b/frontend/src/Pages/AdminPanel.tsx
@@ -1,5 +1,5 @@
 import { Input } from "@chakra-ui/input";
-import { API_URL, AuthToken } from "../App";
+import { API_URL } from "../App";
 import {
   Editable,
   EditableInput,
@@ -29,16 +29,11 @@ export const ADMIN_PATH = "/admin";
 const ADD_MACHINE_URL = "/add_workstation";
 const REMOVE_MACHINE_URL = "/rm_workstation";
 
-const addMachine = async (
-  hostname: string,
-  group: string,
-  token: AuthToken,
-) => {
+const addMachine = async (hostname: string, group: string) => {
   const resp = await fetch(API_URL + ADMIN_PATH + ADD_MACHINE_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${token.token}`,
     },
     body: JSON.stringify({ hostname, group }),
   });
@@ -51,12 +46,11 @@ const addMachine = async (
   }
 };
 
-const removeMachine = async (hostname: string, token: AuthToken) => {
+const removeMachine = async (hostname: string) => {
   const resp = await fetch(API_URL + ADMIN_PATH + REMOVE_MACHINE_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${token.token}`,
     },
     body: JSON.stringify({ hostname }),
   });
@@ -76,24 +70,17 @@ type ModifyData = {
   notes: string | null;
 };
 
-const modifyInfo = (hostname: string, mod: ModifyData, token: AuthToken) => {
+const modifyInfo = (hostname: string, mod: ModifyData) => {
   fetch(API_URL + ADMIN_PATH + STATS_PATH + "/modify", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${token.token}`,
     },
     body: JSON.stringify({ hostname, ...mod }),
   });
 };
 
-export const AdminPanel = ({
-  token,
-  groups,
-}: {
-  token: AuthToken;
-  groups: WorkStationGroup[];
-}) => {
+export const AdminPanel = ({ groups }: { groups: WorkStationGroup[] }) => {
   const [hostname, setHostname] = useState("");
   const [group, setGroup] = useState("");
 
@@ -129,7 +116,7 @@ export const AdminPanel = ({
         <Button
           w="5%"
           onClick={() => {
-            addMachine(hostname, group, token);
+            addMachine(hostname, group);
           }}
         >
           Add
@@ -162,16 +149,12 @@ export const AdminPanel = ({
                         defaultValue={group}
                         textColor={pickCol(group)}
                         onSubmit={(s) =>
-                          modifyInfo(
-                            workStation.name,
-                            {
-                              group: s,
-                              cpu: null,
-                              motherboard: null,
-                              notes: null,
-                            },
-                            token,
-                          )
+                          modifyInfo(workStation.name, {
+                            group: s,
+                            cpu: null,
+                            motherboard: null,
+                            notes: null,
+                          })
                         }
                       >
                         <EditablePreview />
@@ -185,16 +168,12 @@ export const AdminPanel = ({
                         textColor={pickCol(workStation.cpu)}
                         defaultValue={workStation.cpu}
                         onSubmit={(s) =>
-                          modifyInfo(
-                            workStation.name,
-                            {
-                              group: null,
-                              cpu: s,
-                              motherboard: null,
-                              notes: null,
-                            },
-                            token,
-                          )
+                          modifyInfo(workStation.name, {
+                            group: null,
+                            cpu: s,
+                            motherboard: null,
+                            notes: null,
+                          })
                         }
                       >
                         <EditablePreview />
@@ -208,16 +187,12 @@ export const AdminPanel = ({
                         defaultValue={workStation.motherboard}
                         textColor={pickCol(workStation.motherboard)}
                         onSubmit={(s) =>
-                          modifyInfo(
-                            workStation.name,
-                            {
-                              group: null,
-                              cpu: null,
-                              motherboard: s,
-                              notes: null,
-                            },
-                            token,
-                          )
+                          modifyInfo(workStation.name, {
+                            group: null,
+                            cpu: null,
+                            motherboard: s,
+                            notes: null,
+                          })
                         }
                       >
                         <EditablePreview />
@@ -231,16 +206,12 @@ export const AdminPanel = ({
                         defaultValue={workStation.notes}
                         textColor={pickCol(workStation.notes)}
                         onSubmit={(s) =>
-                          modifyInfo(
-                            workStation.name,
-                            {
-                              group: null,
-                              cpu: null,
-                              motherboard: null,
-                              notes: s,
-                            },
-                            token,
-                          )
+                          modifyInfo(workStation.name, {
+                            group: null,
+                            cpu: null,
+                            motherboard: null,
+                            notes: s,
+                          })
                         }
                       >
                         <EditablePreview />
@@ -251,7 +222,7 @@ export const AdminPanel = ({
                       <Button
                         bgColor={"red.300"}
                         onClick={() => {
-                          removeMachine(hostname, token);
+                          removeMachine(hostname);
                         }}
                       >
                         Kill Satellite

--- a/frontend/src/Pages/AdminPanel.tsx
+++ b/frontend/src/Pages/AdminPanel.tsx
@@ -139,11 +139,11 @@ export const AdminPanel = ({ groups }: { groups: WorkStationGroup[] }) => {
           <Tbody>
             {groups.map(({ name: group, workStations }, i) => {
               return workStations.map((workStation, j) => {
-                const id = (i * j + j) * 5;
+                const id = i * j + j;
                 return (
-                  <Tr>
-                    <Td key={id}> {workStation.name} </Td>
-                    <Td key={id + 1}>
+                  <Tr key={id}>
+                    <Td> {workStation.name} </Td>
+                    <Td>
                       <Editable
                         placeholder="Unknown"
                         defaultValue={group}
@@ -159,10 +159,11 @@ export const AdminPanel = ({ groups }: { groups: WorkStationGroup[] }) => {
                       >
                         <EditablePreview />
                         <EditableInput textColor={"gray.600"} />
-                      </Editable>{" "}
+                      </Editable>
                     </Td>
-                    <Td key={id + 2}>
+                    <Td>
                       {" "}
+                      {/* Do we need this empty string? */}
                       <Editable
                         placeholder="Unknown"
                         textColor={pickCol(workStation.cpu)}
@@ -180,7 +181,7 @@ export const AdminPanel = ({ groups }: { groups: WorkStationGroup[] }) => {
                         <EditableInput textColor={"gray.600"} />
                       </Editable>{" "}
                     </Td>
-                    <Td key={id + 3}>
+                    <Td>
                       {" "}
                       <Editable
                         placeholder="Unknown"
@@ -199,7 +200,7 @@ export const AdminPanel = ({ groups }: { groups: WorkStationGroup[] }) => {
                         <EditableInput textColor={"gray.600"} />
                       </Editable>{" "}
                     </Td>
-                    <Td key={id + 4}>
+                    <Td>
                       {" "}
                       <Editable
                         placeholder="None"

--- a/frontend/src/Pages/AdminPanel.tsx
+++ b/frontend/src/Pages/AdminPanel.tsx
@@ -24,6 +24,7 @@ import {
   AutoCompleteItem,
   AutoCompleteList,
 } from "@choc-ui/chakra-autocomplete";
+import { instKeys } from "../Utils/Utils";
 
 export const ADMIN_PATH = "/admin";
 const ADD_MACHINE_URL = "/add_workstation";
@@ -129,110 +130,111 @@ export const AdminPanel = ({ groups }: { groups: WorkStationGroup[] }) => {
         <Table variant="striped">
           <Thead>
             <Tr>
-              <Th key={0}> Hostname </Th>
-              <Th key={1}> Group </Th>
-              <Th key={2}> CPU </Th>
-              <Th key={3}> Motherboard </Th>
-              <Th key={4}> Notes </Th>
+              <Th> Hostname </Th>
+              <Th> Group </Th>
+              <Th> CPU </Th>
+              <Th> Motherboard </Th>
+              <Th> Notes </Th>
             </Tr>
           </Thead>
           <Tbody>
-            {groups.map(({ name: group, workStations }, i) => {
-              return workStations.map((workStation, j) => {
-                const id = i * j + j;
-                return (
-                  <Tr key={id}>
-                    <Td> {workStation.name} </Td>
-                    <Td>
-                      <Editable
-                        placeholder="Unknown"
-                        defaultValue={group}
-                        textColor={pickCol(group)}
-                        onSubmit={(s) =>
-                          modifyInfo(workStation.name, {
-                            group: s,
-                            cpu: null,
-                            motherboard: null,
-                            notes: null,
-                          })
-                        }
-                      >
-                        <EditablePreview />
-                        <EditableInput textColor={"gray.600"} />
-                      </Editable>
-                    </Td>
-                    <Td>
-                      {" "}
-                      {/* Do we need this empty string? */}
-                      <Editable
-                        placeholder="Unknown"
-                        textColor={pickCol(workStation.cpu)}
-                        defaultValue={workStation.cpu}
-                        onSubmit={(s) =>
-                          modifyInfo(workStation.name, {
-                            group: null,
-                            cpu: s,
-                            motherboard: null,
-                            notes: null,
-                          })
-                        }
-                      >
-                        <EditablePreview />
-                        <EditableInput textColor={"gray.600"} />
-                      </Editable>{" "}
-                    </Td>
-                    <Td>
-                      {" "}
-                      <Editable
-                        placeholder="Unknown"
-                        defaultValue={workStation.motherboard}
-                        textColor={pickCol(workStation.motherboard)}
-                        onSubmit={(s) =>
-                          modifyInfo(workStation.name, {
-                            group: null,
-                            cpu: null,
-                            motherboard: s,
-                            notes: null,
-                          })
-                        }
-                      >
-                        <EditablePreview />
-                        <EditableInput textColor={"gray.600"} />
-                      </Editable>{" "}
-                    </Td>
-                    <Td>
-                      {" "}
-                      <Editable
-                        placeholder="None"
-                        defaultValue={workStation.notes}
-                        textColor={pickCol(workStation.notes)}
-                        onSubmit={(s) =>
-                          modifyInfo(workStation.name, {
-                            group: null,
-                            cpu: null,
-                            motherboard: null,
-                            notes: s,
-                          })
-                        }
-                      >
-                        <EditablePreview />
-                        <EditableInput textColor={"gray.600"} />
-                      </Editable>
-                    </Td>
-                    <Td>
-                      <Button
-                        bgColor={"red.300"}
-                        onClick={() => {
-                          removeMachine(hostname);
-                        }}
-                      >
-                        Kill Satellite
-                      </Button>
-                    </Td>
-                  </Tr>
-                );
-              });
-            })}
+            {instKeys(
+              groups.flatMap(({ name: group, workStations }, i) => {
+                return workStations.map((workStation, j) => {
+                  return (k: number) => (
+                    <Tr key={k}>
+                      <Td> {workStation.name} </Td>
+                      <Td>
+                        <Editable
+                          placeholder="Unknown"
+                          defaultValue={group}
+                          textColor={pickCol(group)}
+                          onSubmit={(s) =>
+                            modifyInfo(workStation.name, {
+                              group: s,
+                              cpu: null,
+                              motherboard: null,
+                              notes: null,
+                            })
+                          }
+                        >
+                          <EditablePreview />
+                          <EditableInput textColor={"gray.600"} />
+                        </Editable>
+                      </Td>
+                      <Td>
+                        {" "}
+                        {/* Do we need this empty string? */}
+                        <Editable
+                          placeholder="Unknown"
+                          textColor={pickCol(workStation.cpu)}
+                          defaultValue={workStation.cpu}
+                          onSubmit={(s) =>
+                            modifyInfo(workStation.name, {
+                              group: null,
+                              cpu: s,
+                              motherboard: null,
+                              notes: null,
+                            })
+                          }
+                        >
+                          <EditablePreview />
+                          <EditableInput textColor={"gray.600"} />
+                        </Editable>{" "}
+                      </Td>
+                      <Td>
+                        {" "}
+                        <Editable
+                          placeholder="Unknown"
+                          defaultValue={workStation.motherboard}
+                          textColor={pickCol(workStation.motherboard)}
+                          onSubmit={(s) =>
+                            modifyInfo(workStation.name, {
+                              group: null,
+                              cpu: null,
+                              motherboard: s,
+                              notes: null,
+                            })
+                          }
+                        >
+                          <EditablePreview />
+                          <EditableInput textColor={"gray.600"} />
+                        </Editable>{" "}
+                      </Td>
+                      <Td>
+                        {" "}
+                        <Editable
+                          placeholder="None"
+                          defaultValue={workStation.notes}
+                          textColor={pickCol(workStation.notes)}
+                          onSubmit={(s) =>
+                            modifyInfo(workStation.name, {
+                              group: null,
+                              cpu: null,
+                              motherboard: null,
+                              notes: s,
+                            })
+                          }
+                        >
+                          <EditablePreview />
+                          <EditableInput textColor={"gray.600"} />
+                        </Editable>
+                      </Td>
+                      <Td>
+                        <Button
+                          bgColor={"red.300"}
+                          onClick={() => {
+                            removeMachine(hostname);
+                          }}
+                        >
+                          Kill Satellite
+                        </Button>
+                      </Td>
+                    </Tr>
+                  );
+                });
+              }),
+            )}
           </Tbody>
         </Table>
       </TableContainer>

--- a/frontend/src/Providers/AuthProvider.tsx
+++ b/frontend/src/Providers/AuthProvider.tsx
@@ -65,7 +65,7 @@ export const AuthProvider = ({ children }: { children: ReactNode[] }) => {
   // On first page load, we would like to check if we are currently signed in
   useOnce(
     discard(async () => {
-      const r = await authFetch("confirm", {
+      const r = await authFetch("/confirm", {
         method: "GET",
       });
       if (r.ok) {

--- a/frontend/src/Providers/AuthProvider.tsx
+++ b/frontend/src/Providers/AuthProvider.tsx
@@ -2,8 +2,8 @@ import React, { ReactNode, createContext, useContext, useState } from "react";
 import {
   Validated,
   Validation,
-  discard,
   failure,
+  fire,
   isSuccess,
   loading,
   success,
@@ -72,7 +72,9 @@ export const AuthProvider = ({ children }: { children: ReactNode[] }) => {
    * 'user'
    */
   const login = (username: string, password: string) => {
-    discard(async () => {
+    fire(async () => {
+      console.log("Tried to log in!");
+
       if (
         DEBUG_AUTH &&
         username === DEBUG_USER &&
@@ -111,7 +113,7 @@ export const AuthProvider = ({ children }: { children: ReactNode[] }) => {
   const useAuthFetch = (path: string, init?: RequestInit | undefined) => {
     const [resp, setResp] = useState<Validation<Response>>(loading());
 
-    discard(async () => {
+    fire(async () => {
       const r = await authFetch(path, init);
       if (!r.ok && r.status === 403) {
         logout();

--- a/frontend/src/Providers/AuthProvider.tsx
+++ b/frontend/src/Providers/AuthProvider.tsx
@@ -1,0 +1,64 @@
+import React, { ReactNode, createContext, useContext, useState } from "react";
+import {
+  Validated,
+  Validation,
+  discard,
+  failure,
+  loading,
+  success,
+} from "../Utils/Utils";
+import { useOnce } from "../Utils/Hooks";
+import { API_URL } from "../App";
+import { ADMIN_PATH } from "../Pages/AdminPanel";
+
+type AuthCtx = {
+  user: Validated<string>;
+  login: (username: string, password: string) => void;
+  logout: () => void;
+  useAuthFetch: (
+    path: string,
+    init?: RequestInit | undefined,
+  ) => Validation<Response>;
+};
+
+const AuthContext = createContext<AuthCtx>({
+  user: failure(Error("No auth context provided")),
+  login: () => {},
+  logout: () => {},
+  useAuthFetch: () => failure(Error("No auth context provided")),
+});
+
+export const useAuth = () => useContext(AuthContext);
+
+export const AuthProvider = ({ children }: { children: ReactNode[] }) => {
+  const [user, setUser] = useState<Validated<string>>(
+    failure(Error("Not logged in!")),
+  );
+
+  const login = (username: string, password: string) => {
+    // Hit /api/auth endpoint
+    setUser(success(username));
+  };
+
+  const logout = () => {
+    setUser(failure(Error("Logged out!")));
+  };
+
+  const useAuthFetch = (path: string, init?: RequestInit | undefined) => {
+    const [resp, setResp] = useState<Validation<Response>>(loading());
+
+    discard(async () => {
+      const r = await fetch(API_URL + ADMIN_PATH + path, init);
+      if (!r.ok && r.status === 403) {
+        logout();
+      }
+      setResp(success(r));
+    });
+
+    return resp;
+  };
+
+  const value = { user, login, logout, useAuthFetch };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};

--- a/frontend/src/Providers/AuthProvider.tsx
+++ b/frontend/src/Providers/AuthProvider.tsx
@@ -36,10 +36,7 @@ type AuthCtx = {
   isSignedIn: () => boolean;
   login: (username: string, password: string) => void;
   logout: () => void;
-  useAuthFetch: (
-    path: string,
-    init?: RequestInit | undefined,
-  ) => Validation<Response>;
+  useAuthFetch: (path: string, init?: RequestInit) => Validation<Response>;
 };
 
 type UsernameReminder = { username: string };
@@ -52,8 +49,14 @@ const AuthContext = createContext<AuthCtx>({
   useAuthFetch: () => failure(Error("No auth context provided")),
 });
 
-const authFetch = (path: string, init?: RequestInit | undefined) =>
-  fetch(API_URL + ADMIN_PATH + path, init);
+const authFetch = (path: string, init?: RequestInit) => {
+  if (init === undefined) {
+    init = { credentials: "include" };
+  } else {
+    init["credentials"] = "include";
+  }
+  return fetch(API_URL + ADMIN_PATH + path, init);
+};
 
 export const useAuth = () => useContext(AuthContext);
 

--- a/frontend/src/Utils/Utils.tsx
+++ b/frontend/src/Utils/Utils.tsx
@@ -50,6 +50,9 @@ export const enumIndex = <E extends EnumDict>(
     [K in EnumType<E>]: number;
   };
 
+export const instKeys = <T,>(xs: ((k: number) => T)[]): T[] =>
+  xs.map((x, i) => x(i));
+
 enum VTag {
   Success = "Success",
   Loading = "Loading",

--- a/frontend/src/Utils/Utils.tsx
+++ b/frontend/src/Utils/Utils.tsx
@@ -14,19 +14,18 @@ export const makeArr = <T,>(size: number, f: (i: number) => T) =>
 /**
  * Fires an asynchronous function but doesn't wait for the result
  */
-export const fire = <T,>(f: () => Promise<T>) => {
-  discard(f)();
+export const fire = <T,>(f: () => Promise<T>): void => {
+  f();
 };
 
 /**
  * Discards the result of an asynchronous function, allowing it to be turned
  * into an ordinary function (where we don't wait for the result)
  */
-export const discard = <T,>(f: () => Promise<T>) => {
-  return () => {
-    f();
-  };
-};
+export const discard =
+  <T,>(f: () => Promise<T>): (() => void) =>
+  () =>
+    fire(f);
 
 export const inlineLog = <T,>(x: T): T => {
   console.log(x);

--- a/frontend/src/Utils/Utils.tsx
+++ b/frontend/src/Utils/Utils.tsx
@@ -14,6 +14,14 @@ export const makeArr = <T,>(size: number, f: (i: number) => T) =>
 /**
  * Fires an asynchronous function but doesn't wait for the result
  */
+export const fire = <T,>(f: () => Promise<T>) => {
+  discard(f)();
+};
+
+/**
+ * Discards the result of an asynchronous function, allowing it to be turned
+ * into an ordinary function (where we don't wait for the result)
+ */
 export const discard = <T,>(f: () => Promise<T>) => {
   return () => {
     f();

--- a/internal/authentication/authentication.go
+++ b/internal/authentication/authentication.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gpuctl/gpuctl/internal/femto"
 )
 
-const TOKEN_KEY = "token"
+const TokenCookieName = "token"
 
 var (
 	NotAuthenticatedError   = errors.New("User does not have a valid authentication token")
@@ -33,7 +33,7 @@ type Authenticator[AuthCredientals any] interface {
 
 func AuthWrapGet[A any, T any](auth Authenticator[A], handle femto.GetFunc[T]) femto.GetFunc[T] {
 	return func(request *http.Request, logger *slog.Logger) (*femto.Response[T], error) {
-		c, err := request.Cookie(TOKEN_KEY)
+		c, err := request.Cookie(TokenCookieName)
 		if err != nil {
 			return &femto.Response[T]{Status: http.StatusUnauthorized}, NotAuthenticatedError
 		}
@@ -50,7 +50,7 @@ func AuthWrapGet[A any, T any](auth Authenticator[A], handle femto.GetFunc[T]) f
 
 func AuthWrapPost[A any, T any](auth Authenticator[A], handle femto.PostFunc[T]) femto.PostFunc[T] {
 	return func(data T, request *http.Request, logger *slog.Logger) (*femto.EmptyBodyResponse, error) {
-		c, err := request.Cookie(TOKEN_KEY)
+		c, err := request.Cookie(TokenCookieName)
 		if err != nil {
 			return &femto.EmptyBodyResponse{Status: http.StatusUnauthorized}, NotAuthenticatedError
 		}

--- a/internal/authentication/authentication.go
+++ b/internal/authentication/authentication.go
@@ -8,6 +8,8 @@ import (
 	"github.com/gpuctl/gpuctl/internal/femto"
 )
 
+const TOKEN_KEY = "token"
+
 var (
 	NotAuthenticatedError   = errors.New("User does not have a valid authentication token")
 	InvalidCredientalsError = errors.New("Invalid credientals for creating an authentication token")
@@ -31,7 +33,7 @@ type Authenticator[AuthCredientals any] interface {
 
 func AuthWrapGet[A any, T any](auth Authenticator[A], handle femto.GetFunc[T]) femto.GetFunc[T] {
 	return func(request *http.Request, logger *slog.Logger) (*femto.Response[T], error) {
-		c, err := request.Cookie("token")
+		c, err := request.Cookie(TOKEN_KEY)
 		if err != nil {
 			return &femto.Response[T]{Status: http.StatusUnauthorized}, NotAuthenticatedError
 		}
@@ -48,7 +50,7 @@ func AuthWrapGet[A any, T any](auth Authenticator[A], handle femto.GetFunc[T]) f
 
 func AuthWrapPost[A any, T any](auth Authenticator[A], handle femto.PostFunc[T]) femto.PostFunc[T] {
 	return func(data T, request *http.Request, logger *slog.Logger) (*femto.EmptyBodyResponse, error) {
-		c, err := request.Cookie("token")
+		c, err := request.Cookie(TOKEN_KEY)
 		if err != nil {
 			return &femto.EmptyBodyResponse{Status: http.StatusUnauthorized}, NotAuthenticatedError
 		}

--- a/internal/authentication/authentication.go
+++ b/internal/authentication/authentication.go
@@ -13,12 +13,20 @@ var (
 	InvalidCredientalsError = errors.New("Invalid credientals for creating an authentication token")
 )
 
+// These would probably be safer as newtypes, but exactly where to use the raw
+// types and where to use the newtypes is slightly subtle (i.e. should packets
+// from front-end use raw types because those values haven't been checked yet?
+// What about packets we send back to the front-end?) so I would like someone
+// else to worry about refactoring this - NB
 type AuthToken = string
+type Username = string
 
 type Authenticator[AuthCredientals any] interface {
 	CreateToken(AuthCredientals) (AuthToken, error)
 	RevokeToken(AuthToken) error
-	CheckToken(AuthToken) (string, error)
+	// Returns the username associated with the authentication token if it is
+	// valid, otherwise an error
+	CheckToken(AuthToken) (Username, error)
 }
 
 func AuthWrapGet[A any, T any](auth Authenticator[A], handle femto.GetFunc[T]) femto.GetFunc[T] {

--- a/internal/authentication/authentication.go
+++ b/internal/authentication/authentication.go
@@ -19,7 +19,7 @@ type AuthToken = string
 type Authenticator[AuthCredientals any] interface {
 	CreateToken(AuthCredientals) (AuthToken, error)
 	RevokeToken(AuthToken) error
-	CheckToken(AuthToken) bool
+	CheckToken(AuthToken) (string, error)
 }
 
 func AuthWrapGet[A any, T any](auth Authenticator[A], handle femto.GetFunc[T]) femto.GetFunc[T] {
@@ -32,7 +32,8 @@ func AuthWrapGet[A any, T any](auth Authenticator[A], handle femto.GetFunc[T]) f
 			return &femto.Response[T]{Status: http.StatusUnauthorized}, NotAuthenticatedError
 		}
 
-		if !auth.CheckToken(token) {
+		_, err := auth.CheckToken(token)
+		if err != nil {
 			return &femto.Response[T]{Status: http.StatusUnauthorized}, NotAuthenticatedError
 		}
 
@@ -50,7 +51,8 @@ func AuthWrapPost[A any, T any](auth Authenticator[A], handle femto.PostFunc[T])
 			return &femto.EmptyBodyResponse{Status: http.StatusUnauthorized}, NotAuthenticatedError
 		}
 
-		if !auth.CheckToken(token) {
+		_, err := auth.CheckToken(token)
+		if err != nil {
 			return &femto.EmptyBodyResponse{Status: http.StatusUnauthorized}, NotAuthenticatedError
 		}
 		return handle(data, request, logger)

--- a/internal/femto/femto.go
+++ b/internal/femto/femto.go
@@ -123,6 +123,7 @@ func doGet[T any](f *Femto, w http.ResponseWriter, r *http.Request, handle GetFu
 		http.SetCookie(w, &data.Cookies[i])
 	}
 
+	w.WriteHeader(data.Status)
 	_, err = w.Write(jsonb)
 
 	if err != nil {

--- a/internal/femto/femto.go
+++ b/internal/femto/femto.go
@@ -17,6 +17,7 @@ type Femto struct {
 
 type Response[T any] struct {
 	Headers map[string]string
+	Cookies []http.Cookie
 	Body    T
 	Status  int
 }
@@ -118,6 +119,9 @@ func doGet[T any](f *Femto, w http.ResponseWriter, r *http.Request, handle GetFu
 	for key, value := range data.Headers {
 		w.Header().Add(key, value)
 	}
+	for i := range data.Cookies {
+		http.SetCookie(w, &data.Cookies[i])
+	}
 
 	_, err = w.Write(jsonb)
 
@@ -159,13 +163,15 @@ func doPost[T any](f *Femto, w http.ResponseWriter, r *http.Request, handle Post
 	}
 
 	if userErr != nil {
-
 		ise("There was an error in the server when trying to handle the provided request", data.Status, userErr)
 		return
 	}
 
 	for key, value := range data.Headers {
 		w.Header().Add(key, value)
+	}
+	for i := range data.Cookies {
+		http.SetCookie(w, &data.Cookies[i])
 	}
 
 	_, err := w.Write(make([]byte, 0))

--- a/internal/femto/server_test.go
+++ b/internal/femto/server_test.go
@@ -228,8 +228,8 @@ func TestValidAuthentication(t *testing.T) {
 	defer reqGet.Body.Close()
 	reqPost := httptest.NewRequest("POST", "/auth-post", strings.NewReader("{}"))
 	defer reqPost.Body.Close()
-	reqGet.Header.Set("Authorization", "Bearer token")
-	reqPost.Header.Set("Authorization", "Bearer token")
+	reqGet.Header.Set("Cookie", "token=token")
+	reqPost.Header.Set("Cookie", "token=token")
 
 	mux.ServeHTTP(w, reqGet)
 	assert.Equal(t, http.StatusOK, w.Code)

--- a/internal/femto/server_test.go
+++ b/internal/femto/server_test.go
@@ -183,7 +183,7 @@ func (auth TestAuthenticator) RevokeToken(token authentication.AuthToken) error 
 	return nil
 }
 
-func (auth TestAuthenticator) CheckToken(token authentication.AuthToken) (string, error) {
+func (auth TestAuthenticator) CheckToken(token authentication.AuthToken) (authentication.Username, error) {
 	if token != "token" {
 		return "", errors.New("Bad token!")
 	}

--- a/internal/femto/server_test.go
+++ b/internal/femto/server_test.go
@@ -183,8 +183,11 @@ func (auth TestAuthenticator) RevokeToken(token authentication.AuthToken) error 
 	return nil
 }
 
-func (auth TestAuthenticator) CheckToken(token authentication.AuthToken) bool {
-	return token == "token"
+func (auth TestAuthenticator) CheckToken(token authentication.AuthToken) (string, error) {
+	if token != "token" {
+		return "", errors.New("Bad token!")
+	}
+	return "admin", nil
 }
 
 func TestValidAuthentication(t *testing.T) {

--- a/internal/femto/server_test.go
+++ b/internal/femto/server_test.go
@@ -100,7 +100,7 @@ func TestUserError(t *testing.T) {
 
 	mux := new(femto.Femto)
 	femto.OnPost(mux, "/postme", func(s struct{}, r *http.Request, l *slog.Logger) (*femto.EmptyBodyResponse, error) {
-		return nil, errors.New("their is no spoon")
+		return nil, errors.New("there is no spoon")
 	})
 
 	req := httptest.NewRequest("POST", "/postme", bytes.NewBufferString("{}"))
@@ -112,7 +112,7 @@ func TestUserError(t *testing.T) {
 
 	data, err := io.ReadAll(w.Body)
 	assert.NoError(t, err)
-	assert.Contains(t, string(data), "their is no spoon")
+	assert.Contains(t, string(data), "there is no spoon")
 }
 
 func TestGetHappyPath(t *testing.T) {
@@ -125,7 +125,7 @@ func TestGetHappyPath(t *testing.T) {
 	}
 
 	femto.OnGet(mux, "/happy", func(r *http.Request, l *slog.Logger) (*femto.Response[Foo], error) {
-		return &femto.Response[Foo]{Body: Foo{101}}, nil
+		return femto.Ok(Foo{101})
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/happy", nil)
@@ -176,7 +176,7 @@ func TestGetApplicationErr(t *testing.T) {
 type TestAuthenticator struct{}
 
 func (auth TestAuthenticator) CreateToken(unit types.Unit) (authentication.AuthToken, error) {
-	return authentication.TOKEN_KEY, nil
+	return authentication.TokenCookieName, nil
 }
 
 func (auth TestAuthenticator) RevokeToken(token authentication.AuthToken) error {
@@ -200,7 +200,7 @@ func TestValidAuthentication(t *testing.T) {
 
 	getHandler :=
 		func(r *http.Request, l *slog.Logger) (*femto.Response[string], error) {
-			return &femto.Response[string]{Body: "OKGET"}, nil
+			return femto.Ok("OKGET")
 		}
 
 	authenticatedGetHandler :=

--- a/internal/femto/server_test.go
+++ b/internal/femto/server_test.go
@@ -176,7 +176,7 @@ func TestGetApplicationErr(t *testing.T) {
 type TestAuthenticator struct{}
 
 func (auth TestAuthenticator) CreateToken(unit types.Unit) (authentication.AuthToken, error) {
-	return "token", nil
+	return authentication.TOKEN_KEY, nil
 }
 
 func (auth TestAuthenticator) RevokeToken(token authentication.AuthToken) error {

--- a/internal/webapi/authenticators.go
+++ b/internal/webapi/authenticators.go
@@ -48,7 +48,7 @@ func (auth *ConfigFileAuthenticator) RevokeToken(token authentication.AuthToken)
 	return nil
 }
 
-func (auth *ConfigFileAuthenticator) CheckToken(token authentication.AuthToken) (string, error) {
+func (auth *ConfigFileAuthenticator) CheckToken(token authentication.AuthToken) (authentication.Username, error) {
 	auth.mu.Lock()
 	defer auth.mu.Unlock()
 

--- a/internal/webapi/authenticators.go
+++ b/internal/webapi/authenticators.go
@@ -1,6 +1,7 @@
 package webapi
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/google/uuid"
@@ -47,9 +48,13 @@ func (auth *ConfigFileAuthenticator) RevokeToken(token authentication.AuthToken)
 	return nil
 }
 
-func (auth *ConfigFileAuthenticator) CheckToken(token authentication.AuthToken) bool {
+func (auth *ConfigFileAuthenticator) CheckToken(token authentication.AuthToken) (string, error) {
 	auth.mu.Lock()
 	defer auth.mu.Unlock()
 
-	return auth.CurrentTokens[token]
+	if !auth.CurrentTokens[token] {
+		return "", errors.New("Bad token!")
+	}
+
+	return auth.Username, nil
 }

--- a/internal/webapi/authenticators_test.go
+++ b/internal/webapi/authenticators_test.go
@@ -31,7 +31,8 @@ func TestConfigFileAuthenticatorRace(t *testing.T) {
 				return
 			}
 			for c := 0; c < 10; c++ {
-				if !auth.CheckToken(token) {
+				_, err := auth.CheckToken(token)
+				if err != nil {
 					failed = false
 					return
 				}
@@ -64,8 +65,8 @@ func TestAuthenticatorFromConfig(t *testing.T) {
 type alwaysAuth struct{}
 
 // CheckToken implements femto.Authenticator.
-func (alwaysAuth) CheckToken(string) bool {
-	return true
+func (alwaysAuth) CheckToken(string) (string, error) {
+	return "admin", nil
 }
 
 // CreateToken implements femto.Authenticator.

--- a/internal/webapi/authenticators_test.go
+++ b/internal/webapi/authenticators_test.go
@@ -65,7 +65,7 @@ func TestAuthenticatorFromConfig(t *testing.T) {
 type alwaysAuth struct{}
 
 // CheckToken implements femto.Authenticator.
-func (alwaysAuth) CheckToken(string) (string, error) {
+func (alwaysAuth) CheckToken(string) (authentication.Username, error) {
 	return "admin", nil
 }
 

--- a/internal/webapi/server.go
+++ b/internal/webapi/server.go
@@ -114,7 +114,7 @@ func (a *Api) Authenticate(auth authentication.Authenticator[APIAuthCredientals]
 	}
 
 	cookies := []http.Cookie{{
-		Name:     "token",
+		Name:     authentication.TOKEN_KEY,
 		Value:    token,
 		Path:     "/",
 		MaxAge:   3600,
@@ -160,15 +160,13 @@ type UsernameReminder struct {
 }
 
 func (a *Api) confirmAdmin(auth authentication.Authenticator[APIAuthCredientals], r *http.Request, l *slog.Logger) (*femto.Response[UsernameReminder], error) {
-	// We need to figure out how to get the token out of a request...
-
-	c, err := r.Cookie("token")
+	c, err := r.Cookie(authentication.TOKEN_KEY)
 	if err != nil {
-		return nil, err
+		return &femto.Response[UsernameReminder]{Status: http.StatusUnauthorized}, nil
 	}
 	u, err := auth.CheckToken(c.Value)
 	if err != nil {
-		return nil, err
+		return &femto.Response[UsernameReminder]{Status: http.StatusUnauthorized}, nil
 	}
 	return femto.Ok(UsernameReminder{Username: u})
 }

--- a/internal/webapi/server.go
+++ b/internal/webapi/server.go
@@ -114,13 +114,13 @@ func (a *Api) Authenticate(auth authentication.Authenticator[APIAuthCredientals]
 	}
 
 	cookies := []http.Cookie{{
-		Name:     authentication.TOKEN_KEY,
+		Name:     authentication.TokenCookieName,
 		Value:    token,
 		Path:     "/",
 		MaxAge:   3600,
 		HttpOnly: true,
 		Secure:   true,
-		SameSite: http.SameSiteLaxMode,
+		SameSite: http.SameSiteStrictMode,
 	}}
 
 	return &femto.EmptyBodyResponse{Cookies: cookies, Status: http.StatusAccepted}, nil
@@ -160,7 +160,8 @@ type UsernameReminder struct {
 }
 
 func (a *Api) confirmAdmin(auth authentication.Authenticator[APIAuthCredientals], r *http.Request, l *slog.Logger) (*femto.Response[UsernameReminder], error) {
-	c, err := r.Cookie(authentication.TOKEN_KEY)
+	c, err := r.Cookie(authentication.TokenCookieName)
+	slog.Info("TEST", "Cookie", c, "Err", err)
 	if err != nil {
 		return &femto.Response[UsernameReminder]{Status: http.StatusUnauthorized}, nil
 	}

--- a/internal/webapi/server.go
+++ b/internal/webapi/server.go
@@ -148,8 +148,17 @@ func (a *Api) removeMachine(rm broadcast.RemoveMachineInfo, r *http.Request, l *
 	return femto.Ok(types.Unit{})
 }
 
-func (a *Api) confirmAdmin(r *http.Request, l *slog.Logger) (*femto.EmptyBodyResponse, error) {
-	return femto.Ok(types.Unit{})
+type UsernameReminder struct {
+	Username string `json:"username"`
+}
+
+func (a *Api) confirmAdmin(auth authentication.Authenticator[APIAuthCredientals], r *http.Request, l *slog.Logger) (*femto.Response[UsernameReminder], error) {
+	// We need to figure out how to get the token out of a request...
+	u, err := auth.CheckToken("")
+	if err != nil {
+		return nil, err
+	}
+	return femto.Ok(UsernameReminder{Username: u})
 }
 
 // TODO

--- a/internal/webapi/server.go
+++ b/internal/webapi/server.go
@@ -66,6 +66,8 @@ func NewServer(db database.Database, auth authentication.Authenticator[APIAuthCr
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "http://localhost:3000")
+	// TODO: Maybe unset in Caddyfile???
+	w.Header().Set("Access-Control-Allow-Credentials", "true")
 	s.mux.ServeHTTP(w, r)
 }
 
@@ -111,8 +113,7 @@ func (a *Api) Authenticate(auth authentication.Authenticator[APIAuthCredientals]
 		return nil, err
 	}
 
-	cookies := make([]http.Cookie, 0)
-	cookies = append(cookies, http.Cookie{
+	cookies := []http.Cookie{{
 		Name:     "token",
 		Value:    token,
 		Path:     "/",
@@ -120,7 +121,7 @@ func (a *Api) Authenticate(auth authentication.Authenticator[APIAuthCredientals]
 		HttpOnly: true,
 		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
-	})
+	}}
 
 	return &femto.EmptyBodyResponse{Cookies: cookies, Status: http.StatusAccepted}, nil
 }

--- a/internal/webapi/server_test.go
+++ b/internal/webapi/server_test.go
@@ -33,8 +33,8 @@ func TestAuthenticate(t *testing.T) {
 
 	response, err := api.Authenticate(&auth, creds, mockRequest, mockLogger)
 
-	if len(response.Headers) == 0 {
-		t.Error("Expected an authentication token header")
+	if len(response.Cookies) == 0 {
+		t.Error("Expected an authentication token cookie")
 	}
 
 	if err != nil {

--- a/internal/webapi/server_test.go
+++ b/internal/webapi/server_test.go
@@ -33,8 +33,8 @@ func TestAuthenticate(t *testing.T) {
 
 	response, err := api.Authenticate(&auth, creds, mockRequest, mockLogger)
 
-	if response.Headers["Set-Cookie"] == "" {
-		t.Error("Expected a valid authentication token, got empty string")
+	if len(response.Headers) == 0 {
+		t.Error("Expected an authentication token header")
 	}
 
 	if err != nil {


### PR DESCRIPTION
See https://github.com/gpuctl/gpuctl/issues/136

- Logging out is currently not permanent as the token cookie stays around. It sounds like the best/easiest way to fix this is to add a new endpoint for revoking tokens.
- Also admin actions on the WebAPI might not be checking the admin permissions currently?

I think fixing both of these could be done in follow-up PRs.