### PR TITLE
Cleanup Database Tests

### DIFF
--- a/internal/database/inmemory.go
+++ b/internal/database/inmemory.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"sort"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/gpuctl/gpuctl/internal/broadcast"
@@ -218,16 +219,9 @@ func CalculateAverage(samples []uplink.GPUStatSample) uplink.GPUStatSample {
 	return averagedSample
 }
 
-func (m *inMemory) Drop() error {
+func (m *inMemory) Drop(t *testing.T) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Reset each map to a new, empty instance.
-	m.infos = make(map[string]gpuInfo)
-	m.stats = make(map[string][]uplink.GPUStatSample)
-	m.lastSeen = make(map[string]int64)
-
-	return nil
+	m = nil
 }
 
 func (m *inMemory) NewMachine(machine broadcast.NewMachine) error {

--- a/internal/database/inmemory_test.go
+++ b/internal/database/inmemory_test.go
@@ -53,15 +53,6 @@ func TestAppendDataPoint_Error(t *testing.T) {
 	assert.EqualError(t, err, database.ErrGpuNotPresent.Error())
 }
 
-func TestDrop(t *testing.T) {
-	t.Parallel()
-
-	db := database.InMemory()
-
-	err := db.Drop()
-	assert.NoError(t, err)
-}
-
 func TestLastSeen(t *testing.T) {
 	t.Parallel()
 

--- a/internal/database/inmemory_test.go
+++ b/internal/database/inmemory_test.go
@@ -4,32 +4,7 @@ import (
 	"testing"
 
 	"github.com/gpuctl/gpuctl/internal/database"
-	"github.com/gpuctl/gpuctl/internal/uplink"
-	"github.com/stretchr/testify/assert"
 )
-
-func TestInMemory(t *testing.T) {
-	t.Parallel()
-
-	db := database.InMemory()
-
-	data, err := db.LatestData()
-	assert.NoError(t, err)
-	assert.Empty(t, data)
-
-	err = db.UpdateLastSeen("foo", 0)
-	assert.NoError(t, err)
-
-	err = db.UpdateGPUContext("foo", uplink.GPUInfo{})
-	assert.NoError(t, err)
-
-	err = db.AppendDataPoint(uplink.GPUStatSample{})
-	assert.NoError(t, err)
-
-	data, err = db.LatestData()
-	assert.NoError(t, err)
-	assert.Len(t, data, 1)
-}
 
 func TestInMemoryUnit(t *testing.T) {
 	t.Parallel()
@@ -43,35 +18,7 @@ func TestInMemoryUnit(t *testing.T) {
 	}
 }
 
-func TestAppendDataPoint_Error(t *testing.T) {
-	t.Parallel()
-
-	db := database.InMemory()
-
-	err := db.AppendDataPoint(uplink.GPUStatSample{Uuid: "550e8400-e29b-41d4-a716-446655440000"})
-	assert.Error(t, err)
-	assert.EqualError(t, err, database.ErrGpuNotPresent.Error())
-}
-
-func TestLastSeen(t *testing.T) {
-	t.Parallel()
-
-	db := database.InMemory()
-
-	err := db.UpdateLastSeen("foo", 1234567890)
-	assert.NoError(t, err)
-
-	err = db.UpdateLastSeen("bar", 9876543210)
-	assert.NoError(t, err)
-
-	seen, err := db.LastSeen()
-	assert.NoError(t, err)
-	assert.Len(t, seen, 2)
-
-	expected := []uplink.WorkstationSeen{
-		{Hostname: "foo", LastSeen: 1234567890},
-		{Hostname: "bar", LastSeen: 9876543210},
-	}
-
-	assert.ElementsMatch(t, expected, seen)
-}
+// STOP!!!
+// Don't add any more tests to this file
+// TestInMemoryUnit runs all the unit tests in unit_test.go
+// Add your new test cases there

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -2,6 +2,8 @@ package database
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/gpuctl/gpuctl/internal/broadcast"
 	"github.com/gpuctl/gpuctl/internal/uplink"
 )
@@ -38,5 +40,6 @@ type Database interface {
 	Downsample(time int64) error
 
 	// Drop all tables and data in the db and close the connection
-	Drop() error
+	// Used for testing, not in code
+	Drop(t *testing.T)
 }

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	//	"reflect"
+	"testing"
 	"time"
 
 	"github.com/gpuctl/gpuctl/internal/broadcast"
@@ -518,12 +519,19 @@ func (conn postgresConn) UpdateMachine(machine broadcast.ModifyMachine) error {
 }
 
 // drop all tables we create in the database
-func (conn postgresConn) Drop() error {
+// this function is only for testing purposes
+func (conn postgresConn) Drop(t *testing.T) {
 	_, err := conn.db.Exec(`DROP TABLE stats;
 		DROP TABLE gpus;
 		DROP TABLE machines`)
+	if err != nil {
+		t.Fatalf("Error deleting tables: %v", err)
+	}
 
-	return errors.Join(err, conn.db.Close())
+	err = conn.db.Close()
+	if err != nil {
+		t.Fatalf("Error closing database connection: %v", err)
+	}
 }
 
 func (conn postgresConn) LastSeen() ([]uplink.WorkstationSeen, error) {

--- a/internal/database/postgres_test.go
+++ b/internal/database/postgres_test.go
@@ -32,3 +32,8 @@ func TestPostgres(t *testing.T) {
 		})
 	}
 }
+
+// STOP!!!
+// Don't add any more tests to this file
+// TestInMemoryUnit runs all the unit tests in unit_test.go
+// Add your new test cases there

--- a/internal/database/postgres_test.go
+++ b/internal/database/postgres_test.go
@@ -26,22 +26,7 @@ func TestPostgres(t *testing.T) {
 				t.Fatalf("Failed to open database: %v", err)
 			}
 
-			// TODO: This is a really bad way of doing things, fix this
-
-			/*
-			 * What needs to be fixed here:
-			 * 	- The tests must test the db.Drop() functionality
-			 * 	- Therefore the database must be dropped
-			 * 	- The test cleanup infrastructure must not rely on tested code
-			 * 	- Must find a way to clean-up without using db.Drop() directly
-			 */
-
-			t.Cleanup(func() {
-				err = db.Drop()
-				if err != nil {
-					t.Logf("Got error on cleanup: %v", err)
-				}
-			})
+			t.Cleanup(func() { db.Drop(t) })
 
 			test.F(t, db)
 		})

--- a/internal/database/unit_test.go
+++ b/internal/database/unit_test.go
@@ -293,8 +293,6 @@ func verifyDownsampledData(t *testing.T, db database.Database, gpuID string, exp
 }
 
 func testAppendDataPointMissingGPU(t *testing.T, db database.Database) {
-	t.Parallel()
-
 	err := db.AppendDataPoint(uplink.GPUStatSample{Uuid: "bogus_uuid_blah"})
 	assert.Error(t, err)
 	assert.EqualError(t, err, database.ErrGpuNotPresent.Error())

--- a/internal/database/unit_test.go
+++ b/internal/database/unit_test.go
@@ -31,7 +31,6 @@ var UnitTests = [...]unitTest{
 	{"TestAppendDataPointMissingGPU", testAppendDataPointMissingGPU},
 	{"LastSeen", testLastSeen},
 	{"Downsample", testDownsample},
-	{"TestSuccessfulDrop", dropSuccess}, 
 }
 
 // fake data for adding during tests
@@ -188,15 +187,6 @@ func multipleHeartbeats(t *testing.T, db database.Database) {
 	err = db.UpdateLastSeen("otter", 0)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
-	}
-}
-
-func dropSuccess(t *testing.T, db database.Database) {
-	t.Parallel()
-
-	err := db.Drop()
-	if err != nil {
-		t.Fatalf("Error dropping database: %v", err)
 	}
 }
 

--- a/internal/database/unit_test.go
+++ b/internal/database/unit_test.go
@@ -29,9 +29,9 @@ var UnitTests = [...]unitTest{
 	{"AppendedDataPointsAreSaved", appendedDataPointsAreSaved},
 	{"MultipleHeartbeats", multipleHeartbeats},
 	{"TestAppendDataPointMissingGPU", testAppendDataPointMissingGPU},
-	unitTest{"LastSeen", testLastSeen},
-	unitTest{"Downsample", testDownsample},
-	unitTest{"TestSuccessfulDrop", dropSuccess}, // Must be last unit test as database tables are dropped here :)
+	{"LastSeen", testLastSeen},
+	{"Downsample", testDownsample},
+	{"TestSuccessfulDrop", dropSuccess}, 
 }
 
 // fake data for adding during tests

--- a/internal/database/unit_test.go
+++ b/internal/database/unit_test.go
@@ -29,8 +29,10 @@ var UnitTests = [...]unitTest{
 	{"AppendedDataPointsAreSaved", appendedDataPointsAreSaved},
 	{"MultipleHeartbeats", multipleHeartbeats},
 	{"TestAppendDataPointMissingGPU", testAppendDataPointMissingGPU},
-	{"LastSeen", testLastSeen},
+	{"LastSeen1", testLastSeen1},
+	{"LastSeen2", testLastSeen2},
 	{"Downsample", testDownsample},
+	{"OneGpu", oneGpu},
 }
 
 // fake data for adding during tests
@@ -204,7 +206,7 @@ func testDownsample(t *testing.T, db database.Database) {
 	verifyDownsampledData(t, db, "Test GPU", 101) // 101 here might not be true
 }
 
-func testLastSeen(t *testing.T, db database.Database) {
+func testLastSeen1(t *testing.T, db database.Database) {
 	host := "TestHost"
 	lastSeenTime := time.Now().Unix()
 	db.UpdateLastSeen(host, lastSeenTime)
@@ -224,6 +226,25 @@ func testLastSeen(t *testing.T, db database.Database) {
 	if !found {
 		t.Errorf("Last seen data for host %s was not updated correctly", host)
 	}
+}
+
+func testLastSeen2(t *testing.T, db database.Database) {
+	err := db.UpdateLastSeen("foo", 1234567890)
+	assert.NoError(t, err)
+
+	err = db.UpdateLastSeen("bar", 9876543210)
+	assert.NoError(t, err)
+
+	seen, err := db.LastSeen()
+	assert.NoError(t, err)
+	assert.Len(t, seen, 2)
+
+	expected := []uplink.WorkstationSeen{
+		{Hostname: "foo", LastSeen: 1234567890},
+		{Hostname: "bar", LastSeen: 9876543210},
+	}
+
+	assert.ElementsMatch(t, expected, seen)
 }
 
 func populateDatabaseWithSampleData(db database.Database, gpuID string, numberOfSamples int) {
@@ -296,4 +317,24 @@ func testAppendDataPointMissingGPU(t *testing.T, db database.Database) {
 	err := db.AppendDataPoint(uplink.GPUStatSample{Uuid: "bogus_uuid_blah"})
 	assert.Error(t, err)
 	assert.EqualError(t, err, database.ErrGpuNotPresent.Error())
+}
+
+// test getting data all the way to a GPU
+func oneGpu(t *testing.T, db database.Database) {
+	data, err := db.LatestData()
+	assert.NoError(t, err)
+	assert.Empty(t, data)
+
+	err = db.UpdateLastSeen("foo", 0)
+	assert.NoError(t, err)
+
+	err = db.UpdateGPUContext("foo", uplink.GPUInfo{})
+	assert.NoError(t, err)
+
+	err = db.AppendDataPoint(uplink.GPUStatSample{})
+	assert.NoError(t, err)
+
+	data, err = db.LatestData()
+	assert.NoError(t, err)
+	assert.Len(t, data, 1)
 }


### PR DESCRIPTION
- Remove tests of `Drop()`
- Make inmemory-specific tests generic in terms of `Database` and move them to `unit_tests.go` so they're run on the in-memory and postgres implementations

See commit messages for justification.