### PR TITLE
database: Remove `Drop` from database interface.

### DIFF
--- a/internal/database/inmemory.go
+++ b/internal/database/inmemory.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 	"sort"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/gpuctl/gpuctl/internal/broadcast"
@@ -217,11 +216,6 @@ func CalculateAverage(samples []uplink.GPUStatSample) uplink.GPUStatSample {
 	}
 
 	return averagedSample
-}
-
-func (m *inMemory) Drop(t *testing.T) {
-	m.mu.Lock()
-	m = nil
 }
 
 func (m *inMemory) NewMachine(machine broadcast.NewMachine) error {

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"errors"
-	"testing"
 
 	"github.com/gpuctl/gpuctl/internal/broadcast"
 	"github.com/gpuctl/gpuctl/internal/uplink"
@@ -38,8 +37,4 @@ type Database interface {
 
 	// downsample since certain unix time
 	Downsample(time int64) error
-
-	// Drop all tables and data in the db and close the connection
-	// Used for testing, not in code
-	Drop(t *testing.T)
 }


### PR DESCRIPTION
Why? We don't want this called from application code, only tests. To enforce this, we make
it a method on `PostgresConn`, instead of `Database`.

This requires a number of changes:

1. Make `PostgresConn` public
2. Make `Postgres` return a `*PostgresConn`, so it tests can see methods not on the interface.
  - We could have it return a `PostgresConn`, but then it isn't nil-able, so error handling suffers.
3. Make `*PostgresConn` implement `Database` (instead of `postgresConn`), so we can use pointer return.
