### PR TITLE
launch-dev: Build go binaries

### DIFF
--- a/launch-dev
+++ b/launch-dev
@@ -7,6 +7,8 @@
 
 set -e
 
+make
+
 # Variables
 SATELLITE_BIN="./satellite"
 SATELLITE_LOGS=$SATELLITE_BIN.log


### PR DESCRIPTION
This avoids the case where the binaries don't exist, or are out of date.
