### PR TITLE
Consolidate ssh code into `onboard`.

### DIFF
--- a/cmd/onboard/main.go
+++ b/cmd/onboard/main.go
@@ -45,13 +45,11 @@ func main() {
 		log.Fatalf("Unable to parse key file %s: %v", *keypath, err)
 	}
 
-	err = onboard.Onboard(
-		*user,
-		*remote,
-		dataDir,
-		signer,
-		ssh.InsecureIgnoreHostKey(),
-		config.SatelliteConfiguration{
+	conf := onboard.Config{
+		User:    *user,
+		DataDir: dataDir,
+		Signer:  signer,
+		RemoteConf: config.SatelliteConfiguration{
 			Groundstation: config.Groundstation{"https://", "gpuctl.perial.co.uk", 80},
 			Satellite: config.Satellite{
 				DataInterval:      int(10 * time.Second),
@@ -60,7 +58,9 @@ func main() {
 				Cache:             "/data/gpuctl/cache",
 			},
 		},
-	)
+	}
+
+	err = onboard.Onboard(*remote, conf)
 
 	if err != nil {
 		log.Fatal(err)

--- a/internal/groundstation/autocontact.go
+++ b/internal/groundstation/autocontact.go
@@ -1,28 +1,15 @@
 package groundstation
 
 import (
-	"errors"
-	"fmt"
 	"log/slog"
 	"os/exec"
 	"time"
 
 	"github.com/gpuctl/gpuctl/internal/database"
 	"github.com/gpuctl/gpuctl/internal/onboard"
-	"golang.org/x/crypto/ssh"
 )
 
-var (
-	InvalidSignerError = errors.New("signer is nil")
-)
-
-type SSHConfig struct {
-	User    string
-	Signer  ssh.Signer
-	BinPath string
-}
-
-func MonitorForDeadMachines(interval time.Duration, database database.Database, timespanForDeath time.Duration, l *slog.Logger, s SSHConfig) error {
+func MonitorForDeadMachines(interval time.Duration, database database.Database, timespanForDeath time.Duration, l *slog.Logger, s onboard.Config) error {
 	downsampleTicker := time.NewTicker(interval)
 
 	for t := range downsampleTicker.C {
@@ -36,7 +23,7 @@ func MonitorForDeadMachines(interval time.Duration, database database.Database, 
 	return nil
 }
 
-func monitor(database database.Database, t time.Time, timespanForDeath time.Duration, l *slog.Logger, s SSHConfig) error {
+func monitor(database database.Database, t time.Time, timespanForDeath time.Duration, l *slog.Logger, s onboard.Config) error {
 	lastSeens, err := database.LastSeen()
 
 	if err != nil {
@@ -48,47 +35,13 @@ func monitor(database database.Database, t time.Time, timespanForDeath time.Dura
 
 		if seen.LastSeen < t.Add(-1*timespanForDeath*time.Second).Unix() {
 			if ping(seen.Hostname, l) {
-				err := sshRestart(seen.Hostname, l, s)
+				err := onboard.RestartSatellite(seen.Hostname, s)
 
 				if err != nil {
 					return err
 				}
 			}
 		}
-	}
-
-	return nil
-}
-
-func sshRestart(remote string, l *slog.Logger, s SSHConfig) error {
-	signer := s.Signer
-	user := s.User
-	dataDir := s.BinPath
-
-	if signer == nil {
-		return InvalidSignerError
-	}
-
-	config := &ssh.ClientConfig{
-		User: user,
-		Auth: []ssh.AuthMethod{ssh.PublicKeys(signer)},
-		// FIXME: Maybe be more secure??
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-	}
-
-	client, err := ssh.Dial("tcp", remote+":22", config)
-	if err != nil {
-		l.Error("Failed to connect to", "remote", remote, "error", err)
-		return err
-	}
-	defer client.Close()
-
-	err = onboard.RunCommand(client, fmt.Sprintf("nohup %s/satellite >> %s/satellite.log 2>> %s/satellite.err < /dev/null &",
-		dataDir, dataDir, dataDir))
-
-	if err != nil {
-		l.Error("Failed to run command on remote:", "error", err)
-		return err
 	}
 
 	return nil

--- a/internal/onboard/onboard.go
+++ b/internal/onboard/onboard.go
@@ -2,6 +2,7 @@ package onboard
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -13,35 +14,41 @@ import (
 	"github.com/gpuctl/gpuctl/internal/config"
 )
 
-// Onboard with copy over and start the satellite on a remote machine, via SSH.
+var InvalidConfigError = errors.New("onboard: invalid config")
+
+type Config struct {
+	// The login to run the satellite on other machines as
+	User string
+	// The directory to store the satellite binary on remotes as
+	DataDir string
+	// The configuration to install on the remote.
+	RemoteConf config.SatelliteConfiguration
+
+	// SSH Options.
+	Signer      ssh.Signer
+	KeyCallback ssh.HostKeyCallback
+}
+
+// Onboard will copy over and start the satellite on a remote machine, via SSH.
 //
 // - hostname must be an amd64 linux system
-// - user@hostname must have permissions to ssh, when signed in with signer
-// - user must have permissions to dataDir
-// - dataDir must be machine-local (IE not on NFS)
-// - hostKeyCallback will be used to verify the identity of the remote
+// - conf.User@hostname must have permissions to ssh, when signed in with signer
+// - conf.User must have permissions to dataDir
+// - conf.DataDir must be machine-local (IE not on NFS)
+// - conf.HostKeyCallback will be used to verify the identity of the remote
 func Onboard(
 	hostname string,
-	user string,
-	dataDir string,
-	signer ssh.Signer,
-	keyCallback ssh.HostKeyCallback,
-	satConfig config.SatelliteConfiguration,
+	conf Config,
 ) error {
 	// -- Connect to Remote --
-	sshConfig := &ssh.ClientConfig{
-		User:            user,
-		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
-		HostKeyCallback: keyCallback,
-	}
-	client, err := ssh.Dial("tcp", hostname+":22", sshConfig)
+	client, err := sshInto(hostname, conf)
 	if err != nil {
 		return err
 	}
 	defer client.Close()
 
 	// -- Make the data dir --
-	err = RunCommand(client, "mkdir -p "+dataDir)
+	err = runCommand(client, "mkdir -p "+conf.DataDir)
 	if err != nil {
 		return fmt.Errorf("failed to mkdir: %w", err)
 	}
@@ -54,7 +61,7 @@ func Onboard(
 
 	err = scpClient.CopyToRemote(
 		bytes.NewReader(assets.SatelliteAmd64Linux),
-		dataDir+"/satellite",
+		conf.DataDir+"/satellite",
 		&scp.FileTransferOption{Perm: 0o755},
 	)
 	if err != nil {
@@ -62,13 +69,13 @@ func Onboard(
 	}
 
 	// -- SCP over the config.toml --
-	configToml, err := config.ToToml(satConfig)
+	configToml, err := config.ToToml(conf.RemoteConf)
 	if err != nil {
 		return err
 	}
 	err = scpClient.CopyToRemote(
 		strings.NewReader(configToml),
-		dataDir+"/satellite.toml",
+		conf.DataDir+"/satellite.toml",
 		&scp.FileTransferOption{},
 	)
 	if err != nil {
@@ -76,10 +83,7 @@ func Onboard(
 	}
 
 	// -- Start the satellite --
-	err = RunCommand(client,
-		fmt.Sprintf("nohup %s/satellite >> %s/satellite.log 2>> %s/satellite.err < /dev/null &",
-			dataDir, dataDir, dataDir),
-	)
+	err = startSatellite(client, conf)
 	if err != nil {
 		return fmt.Errorf("failed to launch satellite on remote: %w", err)
 	}
@@ -87,33 +91,61 @@ func Onboard(
 	return nil
 }
 
+func RestartSatellite(hostname string, conf Config) error {
+	client, err := sshInto(hostname, conf)
+	if err != nil {
+		return err
+	}
+
+	return startSatellite(client, conf)
+}
+
+func startSatellite(client *ssh.Client, conf Config) error {
+	dataDir := conf.DataDir
+	command := fmt.Sprintf(
+		"nohup %s/satellite >> %s/satellite.log 2>> %s/satellite.err < /dev/null &",
+		dataDir, dataDir, dataDir,
+	)
+	return runCommand(client, command)
+}
+
 func Deboard(
 	hostname string,
-	user string,
-	signer ssh.Signer,
-	keyCallback ssh.HostKeyCallback,
+	conf Config,
 ) error {
-	sshConfig := &ssh.ClientConfig{
-		User:            user,
-		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
-		HostKeyCallback: keyCallback,
-	}
-	client, err := ssh.Dial("tcp", hostname+":22", sshConfig)
+	client, err := sshInto(hostname, conf)
 	if err != nil {
 		return err
 	}
 	defer client.Close()
 
-	err = RunCommand(client, "killall satellite")
-
+	err = runCommand(client, "killall satellite")
 	if err != nil {
 		return fmt.Errorf("failed to kill satellite on remote: %w", err)
 	}
-
 	return nil
 }
 
-func RunCommand(client *ssh.Client, command string) error {
+func sshInto(hostname string, conf Config) (*ssh.Client, error) {
+	if conf.User == "" {
+		return nil, fmt.Errorf("%w: User must be set", InvalidConfigError)
+	}
+	if conf.Signer == nil {
+		return nil, fmt.Errorf("%w: Signer must be set", InvalidConfigError)
+	}
+	if conf.KeyCallback == nil {
+		return nil, fmt.Errorf("%w: KetCallback must be set", InvalidConfigError)
+	}
+
+	sshConfig := &ssh.ClientConfig{
+		User:            conf.User,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(conf.Signer)},
+		HostKeyCallback: conf.KeyCallback,
+	}
+	return ssh.Dial("tcp", hostname+":22", sshConfig)
+}
+
+func runCommand(client *ssh.Client, command string) error {
 	sess, err := client.NewSession()
 	if err != nil {
 		return err

--- a/internal/onboard/restart_test.go
+++ b/internal/onboard/restart_test.go
@@ -1,0 +1,55 @@
+package onboard_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"net"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gpuctl/gpuctl/internal/onboard"
+)
+
+func TestSSHRestart_UnreadableKey(t *testing.T) {
+	t.Parallel()
+
+	// Setup
+	sshConfig := onboard.Config{User: "testuser"}
+
+	err := onboard.RestartSatellite("localhost", sshConfig)
+
+	if !errors.Is(err, onboard.InvalidConfigError) {
+		t.Errorf("expected InvalidConfigError, but got %v", err)
+	}
+}
+
+func TestSSHRestart_ValidKey(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate RSA private key: %v", err)
+	}
+
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatalf("Failed to create SSH signer: %v", err)
+	}
+
+	sshConfig := onboard.Config{
+		User:        "dummyUser",
+		Signer:      signer,
+		KeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	err = onboard.RestartSatellite("invalid.remote.address", sshConfig)
+
+	var opError *net.OpError
+	if errors.As(err, &opError) && opError.Err != nil {
+		t.Logf("Expected error occurred: %v", err)
+	} else if err != nil {
+		t.Errorf("Expected sshRestart to fail due to 'no such host', but it failed with a different error: %v", err)
+	} else {
+		t.Error("Expected an error due to invalid setup, but sshRestart did not fail as expected")
+	}
+}

--- a/internal/webapi/onboard.go
+++ b/internal/webapi/onboard.go
@@ -8,12 +8,12 @@ import (
 	"github.com/gpuctl/gpuctl/internal/broadcast"
 	"github.com/gpuctl/gpuctl/internal/femto"
 	"github.com/gpuctl/gpuctl/internal/onboard"
+	"github.com/gpuctl/gpuctl/internal/types"
 )
 
 func (a *Api) onboard(data broadcast.OnboardReq, _ *http.Request, log *slog.Logger) (*femto.EmptyBodyResponse, error) {
 
 	hostname := data.Hostname
-
 	conf := a.onboardConf
 
 	if hostname == "" {
@@ -21,25 +21,12 @@ func (a *Api) onboard(data broadcast.OnboardReq, _ *http.Request, log *slog.Logg
 		return nil, errors.New("hostname cannot be empty")
 	}
 
-	// We error here, instead of on startup, so the rest of the API
-	// methods will still work.
-	if conf.DataDir == "" {
-		return nil, errors.New("`Onboard.datadir` must be set")
-	}
-	if conf.Signer == nil {
-		return nil, errors.New("no ssh key given to server")
-	}
-	if conf.Username == "" {
-		return nil, errors.New("`Onboard.username` must be set")
+	err := onboard.Onboard(hostname, conf)
+	if err != nil {
+		return nil, err
 	}
 
-	return &femto.EmptyBodyResponse{}, onboard.Onboard(hostname,
-		conf.Username,
-		conf.DataDir,
-		conf.Signer,
-		conf.KeyCallback,
-		conf.RemoteConf,
-	)
+	return femto.Ok(types.Unit{})
 }
 
 func (a *Api) deboard(data broadcast.RemoveMachineInfo,
@@ -54,14 +41,5 @@ func (a *Api) deboard(data broadcast.RemoveMachineInfo,
 		return errors.New("hostname cannot be empty")
 	}
 
-	// We error here, instead of on startup, so the rest of the API
-	// methods will still work.
-	if conf.Signer == nil {
-		return errors.New("no ssh key given to server")
-	}
-	if conf.Username == "" {
-		return errors.New("`Onboard.username` must be set")
-	}
-
-	return onboard.Deboard(hostname, conf.Username, conf.Signer, conf.KeyCallback)
+	return onboard.Deboard(hostname, conf)
 }

--- a/internal/webapi/server.go
+++ b/internal/webapi/server.go
@@ -8,12 +8,11 @@ import (
 
 	"github.com/gpuctl/gpuctl/internal/authentication"
 	"github.com/gpuctl/gpuctl/internal/broadcast"
-	"github.com/gpuctl/gpuctl/internal/config"
 	"github.com/gpuctl/gpuctl/internal/database"
 	"github.com/gpuctl/gpuctl/internal/femto"
+	"github.com/gpuctl/gpuctl/internal/onboard"
 	"github.com/gpuctl/gpuctl/internal/types"
 	"github.com/gpuctl/gpuctl/internal/uplink"
-	"golang.org/x/crypto/ssh"
 )
 
 type Server struct {
@@ -22,7 +21,7 @@ type Server struct {
 }
 type Api struct {
 	DB          database.Database
-	onboardConf OnboardConf
+	onboardConf onboard.Config
 }
 
 type APIAuthCredientals struct {
@@ -30,22 +29,9 @@ type APIAuthCredientals struct {
 	Password string
 }
 
-type OnboardConf struct {
-	// The login to run the satellite on other machines as
-	Username string
-	// The directory to store the satellite binary on remotes as
-	DataDir string
-	// The configuration to install on the remote.
-	RemoteConf config.SatelliteConfiguration
-
-	// SSH Options.
-	Signer      ssh.Signer
-	KeyCallback ssh.HostKeyCallback
-}
-
-func NewServer(db database.Database, auth authentication.Authenticator[APIAuthCredientals], onboard OnboardConf) *Server {
+func NewServer(db database.Database, auth authentication.Authenticator[APIAuthCredientals], onboardConf onboard.Config) *Server {
 	mux := new(femto.Femto)
-	api := &Api{db, onboard}
+	api := &Api{db, onboardConf}
 
 	femto.OnGet(mux, "/api/stats/all", api.AllStatistics)
 	femto.OnGet(mux, "/api/stats/offline", api.HandleOfflineMachineRequest)

--- a/internal/webapi/server_test.go
+++ b/internal/webapi/server_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gpuctl/gpuctl/internal/authentication"
 	"github.com/gpuctl/gpuctl/internal/broadcast"
 	"github.com/gpuctl/gpuctl/internal/database"
+	"github.com/gpuctl/gpuctl/internal/onboard"
 	"github.com/gpuctl/gpuctl/internal/uplink"
 	"github.com/gpuctl/gpuctl/internal/webapi"
 	"github.com/stretchr/testify/assert"
@@ -216,7 +217,7 @@ func TestServerEndpoints(t *testing.T) {
 		CurrentTokens: map[authentication.AuthToken]bool{"example_token": true},
 	}
 
-	server := webapi.NewServer(mockDB, &auth, webapi.OnboardConf{})
+	server := webapi.NewServer(mockDB, &auth, onboard.Config{})
 
 	tests := []struct {
 		name           string


### PR DESCRIPTION
Followup to #150

Advantages:

- Less code
- Single config type for all SSH stuff
- Only one place now needed to change HostKeyCallback
- Only one place where the `nohup` command is
- SSH session creation code consolidated

Disadvantages:

- The `onboard` name is now misleading.
