### PR TITLE
rename `onboard` -> `tunnel`.

### DIFF
--- a/cmd/control/control.go
+++ b/cmd/control/control.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gpuctl/gpuctl/internal/config"
 	"github.com/gpuctl/gpuctl/internal/database"
 	"github.com/gpuctl/gpuctl/internal/groundstation"
-	"github.com/gpuctl/gpuctl/internal/onboard"
+	"github.com/gpuctl/gpuctl/internal/tunnel"
 	"github.com/gpuctl/gpuctl/internal/webapi"
 )
 
@@ -61,7 +61,7 @@ func main() {
 		log.Warn("No SSH key given, will not be able to handle onboard requests")
 	}
 
-	onboardConf := onboard.Config{
+	onboardConf := tunnel.Config{
 		User:        conf.SSH.Username,
 		DataDir:     conf.SSH.DataDir,
 		RemoteConf:  conf.SSH.RemoteConf,

--- a/cmd/control/control.go
+++ b/cmd/control/control.go
@@ -61,7 +61,7 @@ func main() {
 		log.Warn("No SSH key given, will not be able to handle onboard requests")
 	}
 
-	onboardConf := tunnel.Config{
+	tunnelConf := tunnel.Config{
 		User:        conf.SSH.Username,
 		DataDir:     conf.SSH.DataDir,
 		RemoteConf:  conf.SSH.RemoteConf,
@@ -70,7 +70,7 @@ func main() {
 	}
 
 	authenticator := webapi.AuthenticatorFromConfig(conf)
-	wa := webapi.NewServer(db, &authenticator, onboardConf)
+	wa := webapi.NewServer(db, &authenticator, tunnelConf)
 	waPort := config.PortToAddress(conf.Server.WAPort)
 
 	errs := make(chan (error), 1)
@@ -87,7 +87,7 @@ func main() {
 	go func() {
 		monitorInterval := time.Duration(conf.Timeouts.MonitorInterval) * time.Second
 		deathTimeOut := time.Duration(conf.Timeouts.DeathTimeout) * time.Second
-		errs <- groundstation.MonitorForDeadMachines(monitorInterval, db, deathTimeOut, log, onboardConf)
+		errs <- groundstation.MonitorForDeadMachines(monitorInterval, db, deathTimeOut, log, tunnelConf)
 	}()
 
 	slog.Info("started servers")

--- a/cmd/onboard/main.go
+++ b/cmd/onboard/main.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gpuctl/gpuctl/internal/config"
-	"github.com/gpuctl/gpuctl/internal/onboard"
+	"github.com/gpuctl/gpuctl/internal/tunnel"
 )
 
 // This is right on DoC CSG machines.
@@ -45,7 +45,7 @@ func main() {
 		log.Fatalf("Unable to parse key file %s: %v", *keypath, err)
 	}
 
-	conf := onboard.Config{
+	conf := tunnel.Config{
 		User:    *user,
 		DataDir: dataDir,
 		Signer:  signer,
@@ -60,7 +60,7 @@ func main() {
 		},
 	}
 
-	err = onboard.Onboard(*remote, conf)
+	err = tunnel.Onboard(*remote, conf)
 
 	if err != nil {
 		log.Fatal(err)

--- a/internal/groundstation/autocontact.go
+++ b/internal/groundstation/autocontact.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/gpuctl/gpuctl/internal/database"
-	"github.com/gpuctl/gpuctl/internal/onboard"
+	"github.com/gpuctl/gpuctl/internal/tunnel"
 )
 
-func MonitorForDeadMachines(interval time.Duration, database database.Database, timespanForDeath time.Duration, l *slog.Logger, s onboard.Config) error {
+func MonitorForDeadMachines(interval time.Duration, database database.Database, timespanForDeath time.Duration, l *slog.Logger, s tunnel.Config) error {
 	downsampleTicker := time.NewTicker(interval)
 
 	for t := range downsampleTicker.C {
@@ -23,7 +23,7 @@ func MonitorForDeadMachines(interval time.Duration, database database.Database, 
 	return nil
 }
 
-func monitor(database database.Database, t time.Time, timespanForDeath time.Duration, l *slog.Logger, s onboard.Config) error {
+func monitor(database database.Database, t time.Time, timespanForDeath time.Duration, l *slog.Logger, s tunnel.Config) error {
 	lastSeens, err := database.LastSeen()
 
 	if err != nil {
@@ -35,7 +35,7 @@ func monitor(database database.Database, t time.Time, timespanForDeath time.Dura
 
 		if seen.LastSeen < t.Add(-1*timespanForDeath*time.Second).Unix() {
 			if ping(seen.Hostname, l) {
-				err := onboard.RestartSatellite(seen.Hostname, s)
+				err := tunnel.RestartSatellite(seen.Hostname, s)
 
 				if err != nil {
 					return err

--- a/internal/groundstation/autocontact_test.go
+++ b/internal/groundstation/autocontact_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gpuctl/gpuctl/internal/broadcast"
 	"github.com/gpuctl/gpuctl/internal/database"
-	"github.com/gpuctl/gpuctl/internal/onboard"
+	"github.com/gpuctl/gpuctl/internal/tunnel"
 	"github.com/gpuctl/gpuctl/internal/uplink"
 )
 
@@ -88,7 +88,7 @@ func TestMonitorWithErrorDB(t *testing.T) {
 	db := &ErrorDB{}
 	logger := slog.Default()
 
-	sshConfig := onboard.Config{User: "testuser"}
+	sshConfig := tunnel.Config{User: "testuser"}
 
 	currentTime := time.Now()
 	timespanForDeath := 24 * time.Hour
@@ -103,7 +103,7 @@ func TestMonitor(t *testing.T) {
 	db := database.InMemory()
 	logger := slog.Default()
 
-	sshConfig := onboard.Config{User: "testuser"}
+	sshConfig := tunnel.Config{User: "testuser"}
 
 	currentTime := time.Now()
 	db.UpdateLastSeen("machineRecent", currentTime.Unix())                 // This machine should not trigger any action

--- a/internal/tunnel/onboard.go
+++ b/internal/tunnel/onboard.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gpuctl/gpuctl/internal/config"
 )
 
-var InvalidConfigError = errors.New("onboard: invalid config")
+var InvalidConfigError = errors.New("tunnel: invalid config")
 
 type Config struct {
 	// The login to run the satellite on other machines as

--- a/internal/tunnel/onboard.go
+++ b/internal/tunnel/onboard.go
@@ -1,4 +1,4 @@
-package onboard
+package tunnel
 
 import (
 	"bytes"

--- a/internal/tunnel/restart_test.go
+++ b/internal/tunnel/restart_test.go
@@ -1,4 +1,4 @@
-package onboard_test
+package tunnel_test
 
 import (
 	"crypto/rand"
@@ -9,18 +9,18 @@ import (
 
 	"golang.org/x/crypto/ssh"
 
-	"github.com/gpuctl/gpuctl/internal/onboard"
+	"github.com/gpuctl/gpuctl/internal/tunnel"
 )
 
 func TestSSHRestart_UnreadableKey(t *testing.T) {
 	t.Parallel()
 
 	// Setup
-	sshConfig := onboard.Config{User: "testuser"}
+	sshConfig := tunnel.Config{User: "testuser"}
 
-	err := onboard.RestartSatellite("localhost", sshConfig)
+	err := tunnel.RestartSatellite("localhost", sshConfig)
 
-	if !errors.Is(err, onboard.InvalidConfigError) {
+	if !errors.Is(err, tunnel.InvalidConfigError) {
 		t.Errorf("expected InvalidConfigError, but got %v", err)
 	}
 }
@@ -36,13 +36,13 @@ func TestSSHRestart_ValidKey(t *testing.T) {
 		t.Fatalf("Failed to create SSH signer: %v", err)
 	}
 
-	sshConfig := onboard.Config{
+	sshConfig := tunnel.Config{
 		User:        "dummyUser",
 		Signer:      signer,
 		KeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 
-	err = onboard.RestartSatellite("invalid.remote.address", sshConfig)
+	err = tunnel.RestartSatellite("invalid.remote.address", sshConfig)
 
 	var opError *net.OpError
 	if errors.As(err, &opError) && opError.Err != nil {

--- a/internal/webapi/onboard.go
+++ b/internal/webapi/onboard.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gpuctl/gpuctl/internal/broadcast"
 	"github.com/gpuctl/gpuctl/internal/femto"
-	"github.com/gpuctl/gpuctl/internal/onboard"
+	"github.com/gpuctl/gpuctl/internal/tunnel"
 	"github.com/gpuctl/gpuctl/internal/types"
 )
 
@@ -21,7 +21,7 @@ func (a *Api) onboard(data broadcast.OnboardReq, _ *http.Request, log *slog.Logg
 		return nil, errors.New("hostname cannot be empty")
 	}
 
-	err := onboard.Onboard(hostname, conf)
+	err := tunnel.Onboard(hostname, conf)
 	if err != nil {
 		return nil, err
 	}
@@ -41,5 +41,5 @@ func (a *Api) deboard(data broadcast.RemoveMachineInfo,
 		return errors.New("hostname cannot be empty")
 	}
 
-	return onboard.Deboard(hostname, conf)
+	return tunnel.Deboard(hostname, conf)
 }

--- a/internal/webapi/onboard.go
+++ b/internal/webapi/onboard.go
@@ -14,7 +14,7 @@ import (
 func (a *Api) onboard(data broadcast.OnboardReq, _ *http.Request, log *slog.Logger) (*femto.EmptyBodyResponse, error) {
 
 	hostname := data.Hostname
-	conf := a.onboardConf
+	conf := a.tunnelConf
 
 	if hostname == "" {
 		// TODO: return 400 bad request
@@ -34,7 +34,7 @@ func (a *Api) deboard(data broadcast.RemoveMachineInfo,
 	log *slog.Logger) error {
 	hostname := data.Hostname
 
-	conf := a.onboardConf
+	conf := a.tunnelConf
 
 	if hostname == "" {
 		// TODO: return 400 bad request

--- a/internal/webapi/onboard_test.go
+++ b/internal/webapi/onboard_test.go
@@ -43,7 +43,7 @@ func TestOnboardNoKey(t *testing.T) {
 	serv.ServeHTTP(w, req)
 
 	assert.Equal(t, 500, w.Code)
-	assert.Contains(t, w.Body.String(), "onboard: invalid config")
+	assert.Contains(t, w.Body.String(), "tunnel: invalid config")
 }
 
 func TestOnboardNoHostname(t *testing.T) {

--- a/internal/webapi/onboard_test.go
+++ b/internal/webapi/onboard_test.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gpuctl/gpuctl/internal/authentication"
-	"github.com/gpuctl/gpuctl/internal/onboard"
+	"github.com/gpuctl/gpuctl/internal/tunnel"
 	"github.com/gpuctl/gpuctl/internal/webapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,7 +31,7 @@ var emptyAuthCookie = &http.Cookie{Name: authentication.TokenCookieName, Value: 
 func TestOnboardNoKey(t *testing.T) {
 	t.Parallel()
 
-	serv := webapi.NewServer(nil, alwaysAuth{}, onboard.Config{
+	serv := webapi.NewServer(nil, alwaysAuth{}, tunnel.Config{
 		DataDir: "/foo",
 		User:    "JFK",
 	})
@@ -52,7 +52,7 @@ func TestOnboardNoHostname(t *testing.T) {
 	sign, err := ssh.ParsePrivateKey([]byte(demoPrivKey))
 	require.NoError(t, err)
 
-	serv := webapi.NewServer(nil, alwaysAuth{}, onboard.Config{
+	serv := webapi.NewServer(nil, alwaysAuth{}, tunnel.Config{
 		DataDir: "/foo",
 		User:    "root",
 		Signer:  sign,

--- a/internal/webapi/server.go
+++ b/internal/webapi/server.go
@@ -20,8 +20,8 @@ type Server struct {
 	api *Api
 }
 type Api struct {
-	DB          database.Database
-	onboardConf tunnel.Config
+	DB         database.Database
+	tunnelConf tunnel.Config
 }
 
 type APIAuthCredientals struct {
@@ -29,9 +29,9 @@ type APIAuthCredientals struct {
 	Password string
 }
 
-func NewServer(db database.Database, auth authentication.Authenticator[APIAuthCredientals], onboardConf tunnel.Config) *Server {
+func NewServer(db database.Database, auth authentication.Authenticator[APIAuthCredientals], tunnelConf tunnel.Config) *Server {
 	mux := new(femto.Femto)
-	api := &Api{db, onboardConf}
+	api := &Api{db, tunnelConf}
 
 	femto.OnGet(mux, "/api/stats/all", api.AllStatistics)
 	femto.OnGet(mux, "/api/stats/offline", api.HandleOfflineMachineRequest)

--- a/internal/webapi/server.go
+++ b/internal/webapi/server.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gpuctl/gpuctl/internal/broadcast"
 	"github.com/gpuctl/gpuctl/internal/database"
 	"github.com/gpuctl/gpuctl/internal/femto"
-	"github.com/gpuctl/gpuctl/internal/onboard"
+	"github.com/gpuctl/gpuctl/internal/tunnel"
 	"github.com/gpuctl/gpuctl/internal/types"
 	"github.com/gpuctl/gpuctl/internal/uplink"
 )
@@ -21,7 +21,7 @@ type Server struct {
 }
 type Api struct {
 	DB          database.Database
-	onboardConf onboard.Config
+	onboardConf tunnel.Config
 }
 
 type APIAuthCredientals struct {
@@ -29,7 +29,7 @@ type APIAuthCredientals struct {
 	Password string
 }
 
-func NewServer(db database.Database, auth authentication.Authenticator[APIAuthCredientals], onboardConf onboard.Config) *Server {
+func NewServer(db database.Database, auth authentication.Authenticator[APIAuthCredientals], onboardConf tunnel.Config) *Server {
 	mux := new(femto.Femto)
 	api := &Api{db, onboardConf}
 

--- a/internal/webapi/server_test.go
+++ b/internal/webapi/server_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gpuctl/gpuctl/internal/authentication"
 	"github.com/gpuctl/gpuctl/internal/broadcast"
 	"github.com/gpuctl/gpuctl/internal/database"
-	"github.com/gpuctl/gpuctl/internal/onboard"
+	"github.com/gpuctl/gpuctl/internal/tunnel"
 	"github.com/gpuctl/gpuctl/internal/uplink"
 	"github.com/gpuctl/gpuctl/internal/webapi"
 	"github.com/stretchr/testify/assert"
@@ -217,7 +217,7 @@ func TestServerEndpoints(t *testing.T) {
 		CurrentTokens: map[authentication.AuthToken]bool{"example_token": true},
 	}
 
-	server := webapi.NewServer(mockDB, &auth, onboard.Config{})
+	server := webapi.NewServer(mockDB, &auth, tunnel.Config{})
 
 	tests := []struct {
 		name           string


### PR DESCRIPTION
After #159, the old `onboard` package did more than just onboarding. It also could kill the satellite on a remote machine, and start an existing satellite

Therefor, we rename it, as suggested here: https://github.com/gpuctl/gpuctl/pull/159#issuecomment-1952890389

CC @Euphoride 
