### PR TITLE
procinfo: Use `golang.org/x/sys/` instead of `syscall`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/povsister/scp v0.0.0-20210427074412-33febfd9f13e
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.19.0
+	golang.org/x/sys v0.17.0
 )
 
 require (
@@ -20,7 +21,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
From the `syscall` docs:

> NOTE: Most of the functions, types, and constants defined in this package are
> also available in the golang.org/x/sys package. That package has more system
> call support than this one, and most new code should prefer that package where
> possible. See https://golang.org/s/go1.4-syscall for more information.

More concretely, we don't need a typecast on the result, which is nice.
