### PR TITLE
Pass in-use & user information from satellite to frontend through DB

### DIFF
--- a/internal/broadcast/types.go
+++ b/internal/broadcast/types.go
@@ -60,6 +60,8 @@ type GPU struct {
 	MaxGraphicsClock  float64 `json:"max_graphics_clock"` // Mhz
 	MemoryClock       float64 `json:"memory_clock"`       // Mhz
 	MaxMemoryClock    float64 `json:"max_memory_clock"`   // Mhz
+	InUse             bool    `json:"in_user"`            // is this gpu being used?
+	User              string  `json:"user"`               // iff it's being used, who is using this gpu
 }
 
 type OnboardReq struct {

--- a/internal/database/inmemory.go
+++ b/internal/database/inmemory.go
@@ -83,6 +83,18 @@ func (m *inMemory) LatestData() (broadcast.Workstations, error) {
 		// most recent stat is at the end
 		stats := m.stats[uuid]
 		stat := stats[len(stats)-1]
+
+		// add on in-use info
+		// can't be done with reflection because types are different
+		user := "" // user defaults to blank when not in use
+		// determine inUse
+		inUse := len(stat.RunningProcesses) > 0
+		if inUse {
+			user = stat.RunningProcesses[0].Owner
+		}
+		gpu.InUse = inUse
+		gpu.User = user
+
 		// reflect on stat to get all the fields
 		for _, field := range reflect.VisibleFields(reflect.TypeOf(stat)) {
 			// uuid already set, skip

--- a/internal/database/inmemory.go
+++ b/internal/database/inmemory.go
@@ -85,15 +85,7 @@ func (m *inMemory) LatestData() (broadcast.Workstations, error) {
 		stat := stats[len(stats)-1]
 
 		// add on in-use info
-		// can't be done with reflection because types are different
-		user := "" // user defaults to blank when not in use
-		// determine inUse
-		inUse := len(stat.RunningProcesses) > 0
-		if inUse {
-			user = stat.RunningProcesses[0].Owner
-		}
-		gpu.InUse = inUse
-		gpu.User = user
+		gpu.InUse, gpu.User = stat.RunningProcesses.Summarise()
 
 		// reflect on stat to get all the fields
 		for _, field := range reflect.VisibleFields(reflect.TypeOf(stat)) {

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -165,12 +165,7 @@ func updateLastSeen(host string, now time.Time, tx *sql.Tx) (err error) {
 func (conn PostgresConn) AppendDataPoint(sample uplink.GPUStatSample) error {
 	now := time.Now()
 
-	user := "" // user defaults to blank when not in use
-	// determine inUse
-	inUse := len(sample.RunningProcesses) > 0
-	if inUse {
-		user = sample.RunningProcesses[0].Owner
-	}
+	inUse, user := sample.RunningProcesses.Summarise()
 
 	_, err := conn.db.Exec(`INSERT INTO Stats
 		(Gpu, Received, MemoryUtilisation, GpuUtilisation, MemoryUsed,

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -91,6 +91,8 @@ func createTables(db *sql.DB) error {
 		MaxGraphicsClock real NOT NULL,
 		MemoryClock real NOT NULL,
 		MaxMemoryClock real NOT NULL,
+		InUse boolean NOT NULL,
+		UserName text NOT NULL DEFAULT '',
 		PRIMARY KEY (Gpu, Received)
 	);`)
 
@@ -163,18 +165,27 @@ func updateLastSeen(host string, now time.Time, tx *sql.Tx) (err error) {
 func (conn PostgresConn) AppendDataPoint(sample uplink.GPUStatSample) error {
 	now := time.Now()
 
+	user := "" // user defaults to blank when not in use
+	// determine inUse
+	inUse := len(sample.RunningProcesses) > 0
+	if inUse {
+		user = sample.RunningProcesses[0].Owner
+	}
+
 	_, err := conn.db.Exec(`INSERT INTO Stats
 		(Gpu, Received, MemoryUtilisation, GpuUtilisation, MemoryUsed,
 		FanSpeed, Temp, MemoryTemp, GraphicsVoltage, PowerDraw,
-		GraphicsClock, MaxGraphicsClock, MemoryClock, MaxMemoryClock)
+		GraphicsClock, MaxGraphicsClock, MemoryClock, MaxMemoryClock,
+		InUse, UserName)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
-		$14)`,
+		$14, $15, $16)`,
 		sample.Uuid, now,
 		sample.MemoryUtilisation, sample.GPUUtilisation,
 		sample.MemoryUsed, sample.FanSpeed, sample.Temp,
 		sample.MemoryTemp, sample.GraphicsVoltage, sample.PowerDraw,
 		sample.GraphicsClock, sample.MaxGraphicsClock,
-		sample.MemoryClock, sample.MaxMemoryClock)
+		sample.MemoryClock, sample.MaxMemoryClock,
+		inUse, user)
 
 	// TODO: hacky, untested. Might not work
 	if err != nil {
@@ -391,7 +402,7 @@ func getGpus(host string, tx *sql.Tx) ([]broadcast.GPU, error) {
 		s.MemoryUsed, s.FanSpeed, s.Temp, s.MemoryTemp,
 		s.GraphicsVoltage, s.PowerDraw, s.GraphicsClock,
 		s.MaxGraphicsClock, s.MemoryClock,
-		s.MaxMemoryClock
+		s.MaxMemoryClock, s.InUse, s.UserName
 		FROM GPUs g INNER JOIN Stats s ON g.Uuid = s.Gpu
 		INNER JOIN (
 			SELECT Gpu, Max(Received) Received
@@ -416,7 +427,7 @@ func getGpus(host string, tx *sql.Tx) ([]broadcast.GPU, error) {
 			&gpu.MemoryTemp, &gpu.GraphicsVoltage,
 			&gpu.PowerDraw, &gpu.GraphicsClock,
 			&gpu.MaxGraphicsClock, &gpu.MemoryClock,
-			&gpu.MaxMemoryClock)
+			&gpu.MaxMemoryClock, &gpu.InUse, &gpu.User)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/database/prune_test.go
+++ b/internal/database/prune_test.go
@@ -84,24 +84,24 @@ func TestAverageProcess(t *testing.T) {
 
 	testCases := []struct {
 		name    string
-		toMerge [][]uplink.GPUProcInfo
-		merged  []uplink.GPUProcInfo
+		toMerge []uplink.Processes
+		merged  uplink.Processes
 	}{
 		{"Empty", nil, nil},
 		{"Single Sample",
-			[][]uplink.GPUProcInfo{
+			[]uplink.Processes{
 				{{Pid: 1, Name: "foo", MemUsed: 100}, {Pid: 2, Name: "bar", MemUsed: 200}},
 			},
 			[]uplink.GPUProcInfo{{Pid: 1, Name: "foo", MemUsed: 100}, {Pid: 2, Name: "bar", MemUsed: 200}},
 		},
 		{
 			"Three Separate Processes",
-			[][]uplink.GPUProcInfo{
+			[]uplink.Processes{
 				{{Pid: 1, Name: "foo", MemUsed: 100}},
 				{{Pid: 2, Name: "bar", MemUsed: 200}},
 				{{Pid: 3, Name: "baz", MemUsed: 300}},
 			},
-			[]uplink.GPUProcInfo{
+			uplink.Processes{
 				{Pid: 1, Name: "foo", MemUsed: 100},
 				{Pid: 2, Name: "bar", MemUsed: 200},
 				{Pid: 3, Name: "baz", MemUsed: 300},

--- a/internal/database/unit_test.go
+++ b/internal/database/unit_test.go
@@ -87,12 +87,14 @@ func floatsNear(a float64, b float64) bool {
 	return math.Abs(a-b) < margin
 }
 func statsNear(target broadcast.GPU, stat uplink.GPUStatSample, context uplink.GPUInfo) bool {
+	// compare uuids
 	if target.Uuid != stat.Uuid {
 		slog.Error("stat uuid didn't match", "was", target.Uuid, "wanted", stat.Uuid)
 		return false
 	}
 	if target.Uuid != context.Uuid {
 		slog.Error("context uuid didn't match", "was", target.Uuid, "wanted", context.Uuid)
+		return false
 	}
 
 	// compare all the other fields using reflection

--- a/internal/database/unit_test.go
+++ b/internal/database/unit_test.go
@@ -99,27 +99,14 @@ func statsNear(target broadcast.GPU, stat uplink.GPUStatSample, context uplink.G
 	}
 
 	// compare running processes
-	if len(stat.RunningProcesses) > 0 {
-		// in_use should be set if there's at least one running process
-		// user is set if in_use set and is the user from first process
-		if !target.InUse {
-			slog.Error("InUse didn't match", "was", target.InUse, "wanted", "True")
-			return false
-		}
-		if target.User != stat.RunningProcesses[0].Owner {
-			slog.Error("User didn't match", "was", target.User, "wanted", stat.RunningProcesses[0].Owner)
-			return false
-		}
-	} else {
-		// otherwise, in_use should be false and user the empty string
-		if target.InUse {
-			slog.Error("InUse didn't match", "was", target.InUse, "wanted", "False")
-			return false
-		}
-		if target.User != "" {
-			slog.Error("User didn't match", "was", target.User, "wanted", "Empty string")
-			return false
-		}
+	inUse, user := stat.RunningProcesses.Summarise()
+	if target.InUse != inUse {
+		slog.Error("InUse didn't match", "was", target.InUse, "wanted", inUse)
+		return false
+	}
+	if target.User != user {
+		slog.Error("User didn't match", "was", target.User, "wanted", user)
+		return false
 	}
 
 	// compare all the other fields using reflection

--- a/internal/database/unit_test.go
+++ b/internal/database/unit_test.go
@@ -37,6 +37,7 @@ var UnitTests = [...]unitTest{
 	{"MachineInfoStartsEmpty", machineInfoStartsEmpty},
 	{"MachineInfoUpdatesWork", machineInfoUpdatesWork},
 	{"MachinesCanBeRemoved", removingMachine},
+	{"InUseInformation", inUseInformation},
 }
 
 // fake data for adding during tests
@@ -97,6 +98,30 @@ func statsNear(target broadcast.GPU, stat uplink.GPUStatSample, context uplink.G
 		return false
 	}
 
+	// compare running processes
+	if len(stat.RunningProcesses) > 0 {
+		// in_use should be set if there's at least one running process
+		// user is set if in_use set and is the user from first process
+		if !target.InUse {
+			slog.Error("InUse didn't match", "was", target.InUse, "wanted", "True")
+			return false
+		}
+		if target.User != stat.RunningProcesses[0].Owner {
+			slog.Error("User didn't match", "was", target.User, "wanted", stat.RunningProcesses[0].Owner)
+			return false
+		}
+	} else {
+		// otherwise, in_use should be false and user the empty string
+		if target.InUse {
+			slog.Error("InUse didn't match", "was", target.InUse, "wanted", "False")
+			return false
+		}
+		if target.User != "" {
+			slog.Error("User didn't match", "was", target.User, "wanted", "Empty string")
+			return false
+		}
+	}
+
 	// compare all the other fields using reflection
 	for _, compare := range []interface{}{stat, context} {
 		compareV := reflect.ValueOf(compare)
@@ -110,7 +135,7 @@ func statsNear(target broadcast.GPU, stat uplink.GPUStatSample, context uplink.G
 			if field.Name == "Time" {
 				continue
 			}
-			// TODO: Start actually using running processes
+			// we've already checked running processes
 			if field.Name == "RunningProcesses" {
 				continue
 			}
@@ -420,5 +445,69 @@ func removingMachine(t *testing.T, db database.Database) {
 	if found {
 		t.Logf("%v", data)
 		t.Error("Found the machine when we didn't expect to")
+	}
+}
+
+// db layer handles process information
+func inUseInformation(t *testing.T, db database.Database) {
+	fakeHost := "hamster"
+	fakeUuid := "jeff's phone no."
+
+	err := db.UpdateLastSeen(fakeHost, time.Now().Unix())
+	assert.NoError(t, err)
+
+	context := uplink.GPUInfo{
+		Uuid: fakeUuid,
+		Name: "jeff",
+	}
+	noProcesses := uplink.GPUStatSample{
+		Uuid:             fakeUuid,
+		RunningProcesses: make([]uplink.GPUProcInfo, 0),
+	}
+
+	oneProcess := uplink.GPUStatSample{
+		Uuid: fakeUuid,
+		RunningProcesses: []uplink.GPUProcInfo{
+			{
+				Pid:     5678,
+				Name:    "python",
+				MemUsed: 45.2,
+				Owner:   "jeff",
+			},
+		},
+	}
+
+	multipleProcesses := uplink.GPUStatSample{
+		Uuid: fakeUuid,
+		RunningProcesses: []uplink.GPUProcInfo{
+			{
+				Pid:     5678,
+				Name:    "python",
+				MemUsed: 6.2,
+				Owner:   "brenda",
+			},
+			{
+				Pid:     53935,
+				Name:    "python",
+				MemUsed: 103.7,
+				Owner:   "james",
+			},
+		},
+	}
+
+	err = db.UpdateGPUContext(fakeHost, context)
+	assert.NoError(t, err)
+
+	// send with no process information, one process and multiple processes
+	for i, stat := range []uplink.GPUStatSample{noProcesses, oneProcess, multipleProcesses} {
+		slog.Info("Trying user process stat sample", "index", i)
+		err = db.AppendDataPoint(stat)
+		assert.NoError(t, err)
+		data, err := db.LatestData()
+		assert.NoError(t, err)
+		found, _, machine := getMachine(data, fakeHost)
+		assert.True(t, found)
+		assert.Len(t, machine.Gpus, 1)
+		assert.True(t, statsNear(machine.Gpus[0], stat, context))
 	}
 }

--- a/internal/uplink/gpustats.go
+++ b/internal/uplink/gpustats.go
@@ -20,26 +20,38 @@ type GPUInfo struct {
 
 // Temporal statistics for a GPU
 type GPUStatSample struct {
-	Uuid              string        `json:"uuid"`
-	MemoryUtilisation float64       `json:"memory_util"`        // Percentage of memory used
-	GPUUtilisation    float64       `json:"gpu_util"`           // Percentage of memory used
-	MemoryUsed        float64       `json:"memory_used"`        // In megabytes
-	FanSpeed          float64       `json:"fan_speed"`          // Percentage of fan speed
-	Temp              float64       `json:"gpu_temp"`           // Celcius
-	MemoryTemp        float64       `json:"memory_temp"`        // Celcius
-	GraphicsVoltage   float64       `json:"graphics_voltage"`   // Volts
-	PowerDraw         float64       `json:"power_draw"`         // Watts
-	GraphicsClock     float64       `json:"graphics_clock"`     // Mhz
-	MaxGraphicsClock  float64       `json:"max_graphics_clock"` // Mhz
-	MemoryClock       float64       `json:"memory_clock"`       // Mhz
-	MaxMemoryClock    float64       `json:"max_memory_clock"`   // Mhz
-	Time              int64         `json:"time"`
-	RunningProcesses  []GPUProcInfo `json:"processes"` // List of processes running
+	Uuid              string    `json:"uuid"`
+	MemoryUtilisation float64   `json:"memory_util"`        // Percentage of memory used
+	GPUUtilisation    float64   `json:"gpu_util"`           // Percentage of memory used
+	MemoryUsed        float64   `json:"memory_used"`        // In megabytes
+	FanSpeed          float64   `json:"fan_speed"`          // Percentage of fan speed
+	Temp              float64   `json:"gpu_temp"`           // Celcius
+	MemoryTemp        float64   `json:"memory_temp"`        // Celcius
+	GraphicsVoltage   float64   `json:"graphics_voltage"`   // Volts
+	PowerDraw         float64   `json:"power_draw"`         // Watts
+	GraphicsClock     float64   `json:"graphics_clock"`     // Mhz
+	MaxGraphicsClock  float64   `json:"max_graphics_clock"` // Mhz
+	MemoryClock       float64   `json:"memory_clock"`       // Mhz
+	MaxMemoryClock    float64   `json:"max_memory_clock"`   // Mhz
+	Time              int64     `json:"time"`
+	RunningProcesses  Processes `json:"processes"` // List of processes running
 }
 
+type Processes []GPUProcInfo
 type GPUProcInfo struct {
 	Pid     uint64  `json:"pid"`
 	Name    string  `json:"name"`
 	MemUsed float64 `json:"used_memory"`
 	Owner   string  `json:"owner"` // NOTE: This is the user that owns the process
+}
+
+// Summarise a running processes array
+// reduces to boolean specifying whether it's in use and a user
+func (procs Processes) Summarise() (inUse bool, user string) {
+	user = ""
+	inUse = len(procs) > 0
+	if inUse {
+		user = procs[0].Owner
+	}
+	return
 }

--- a/internal/uplink/summarise_test.go
+++ b/internal/uplink/summarise_test.go
@@ -1,0 +1,85 @@
+package uplink_test
+
+import (
+	"testing"
+
+	"github.com/gpuctl/gpuctl/internal/uplink"
+)
+
+// test summarising an empty processes list
+func TestSummariseEmpty(t *testing.T) {
+	p := uplink.Processes{}
+
+	inUse, user := p.Summarise()
+
+	if inUse {
+		t.Errorf("inUse value incorrect. was '%v', wanted false", inUse)
+	}
+
+	if user != "" {
+		t.Errorf("user value incorrect. was '%v', wanted empty string", user)
+	}
+}
+
+// test summarising a single processes list
+func TestSummariseOne(t *testing.T) {
+	fakeUser := "dominic"
+
+	p := uplink.Processes{
+		{
+			Pid:     456,
+			Name:    "python",
+			MemUsed: 456.7,
+			Owner:   fakeUser,
+		},
+	}
+
+	inUse, user := p.Summarise()
+
+	if !inUse {
+		t.Errorf("inUse value incorrect. was '%v', wanted true", inUse)
+	}
+
+	if user != fakeUser {
+		t.Errorf("user value incorrect. was '%v', wanted '%v'", user, fakeUser)
+	}
+}
+
+// test summarising a longer processes list
+// not necessarily the behaviour we want long term, I'm just documenting this behaviour in tests
+func TestSummariseMulti(t *testing.T) {
+	fakeUser1 := "clive"
+	fakeUser2 := "brenda"
+	fakeUser3 := "steve"
+
+	p := uplink.Processes{
+		{
+			Pid:     456,
+			Name:    "python",
+			MemUsed: 456.7,
+			Owner:   fakeUser1,
+		},
+		{
+			Pid:     12345,
+			Name:    "python3",
+			MemUsed: 15.3,
+			Owner:   fakeUser2,
+		},
+		{
+			Pid:     543,
+			Name:    "python",
+			MemUsed: 987.0,
+			Owner:   fakeUser3,
+		},
+	}
+
+	inUse, user := p.Summarise()
+
+	if !inUse {
+		t.Errorf("inUse value incorrect. was '%v', wanted true", inUse)
+	}
+
+	if user != fakeUser1 {
+		t.Errorf("user value incorrect. was '%v', wanted '%v'", user, fakeUser1)
+	}
+}


### PR DESCRIPTION
It's possible for satellite to give the groundstation more than one running process (ie. if more than one person is running python). There's probably a nicer way to handle this, but currently we just use the username from the first process in the list and ignore the rest.

Closes #125
Closes #75 