### PR TITLE
Specify Content-Type when doing manual return

### DIFF
--- a/internal/webapi/server.go
+++ b/internal/webapi/server.go
@@ -76,11 +76,7 @@ func (a *Api) AllStatistics(r *http.Request, l *slog.Logger) (*femto.Response[br
 
 	if data == nil {
 		// dont just return nil, which would not be marshalled properly
-		return &femto.Response[broadcast.Workstations]{
-			Status:  http.StatusOK,
-			Body:    broadcast.Workstations{},
-			Headers: map[string]string{"Content-Type": "application/json"},
-		}, nil
+		return femto.Ok(broadcast.Workstations{})
 	}
 
 	return femto.Ok(data)

--- a/internal/webapi/server.go
+++ b/internal/webapi/server.go
@@ -76,7 +76,11 @@ func (a *Api) AllStatistics(r *http.Request, l *slog.Logger) (*femto.Response[br
 
 	if data == nil {
 		// dont just return nil, which would not be marshalled properly
-		return &femto.Response[broadcast.Workstations]{Status: http.StatusOK, Body: broadcast.Workstations{}}, nil
+		return &femto.Response[broadcast.Workstations]{
+			Status:  http.StatusOK,
+			Body:    broadcast.Workstations{},
+			Headers: map[string]string{"Content-Type": "application/json"},
+		}, nil
 	}
 
 	return femto.Ok(data)


### PR DESCRIPTION
Because content type header was missing, femto was trying to coerce broadcast.Workstations to a binary and failing, due to the variable-length fields.