### PR TITLE
Improve logging of errors in production

### DIFF
--- a/cmd/control/control.go
+++ b/cmd/control/control.go
@@ -76,18 +76,22 @@ func main() {
 	errs := make(chan (error), 1)
 
 	go func() {
-		errs <- http.ListenAndServe(gsPort, gs)
+		err := http.ListenAndServe(gsPort, gs)
+		errs <- fmt.Errorf("groundstation: %w", err)
 	}()
 	go func() {
-		errs <- http.ListenAndServe(waPort, wa)
+		err := http.ListenAndServe(waPort, wa)
+		errs <- fmt.Errorf("webapi: %w", err)
 	}()
 	go func() {
-		errs <- database.DownsampleOverTime(conf.Database.DownsampleInterval, db)
+		err := database.DownsampleOverTime(conf.Database.DownsampleInterval, db)
+		errs <- fmt.Errorf("downsampler: %w", err)
 	}()
 	go func() {
 		monitorInterval := time.Duration(conf.Timeouts.MonitorInterval) * time.Second
 		deathTimeOut := time.Duration(conf.Timeouts.DeathTimeout) * time.Second
-		errs <- groundstation.MonitorForDeadMachines(monitorInterval, db, deathTimeOut, log, tunnelConf)
+		err := groundstation.MonitorForDeadMachines(monitorInterval, db, deathTimeOut, log, tunnelConf)
+		errs <- fmt.Errorf("dead machine monitor: %w", err)
 	}()
 
 	slog.Info("started servers")

--- a/internal/database/prune.go
+++ b/internal/database/prune.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"log/slog"
 	"time"
 )
 
@@ -11,7 +12,7 @@ func DownsampleOverTime(interval int, database Database) error {
 		err := downsampleDatabase(database, t)
 
 		if err != nil {
-			return err
+			slog.Error("Got error whilst downsampling", "err", err)
 		}
 	}
 


### PR DESCRIPTION
- Log the source of an error when one occurs in `control`
- Log errors that occur during down-sampling rather than crashing (helps with #219 in the short term)