### PR TITLE
Change how install directory is derived

### DIFF
--- a/cmd/control/control.go
+++ b/cmd/control/control.go
@@ -62,11 +62,11 @@ func main() {
 	}
 
 	tunnelConf := tunnel.Config{
-		User:        conf.SSH.Username,
-		DataDir:     conf.SSH.DataDir,
-		RemoteConf:  conf.SSH.RemoteConf,
-		Signer:      signer,
-		KeyCallback: ssh.InsecureIgnoreHostKey(), // TODO: Be secure here.
+		User:            conf.SSH.Username,
+		DataDirTemplate: conf.SSH.DataDir,
+		RemoteConf:      conf.SSH.RemoteConf,
+		Signer:          signer,
+		KeyCallback:     ssh.InsecureIgnoreHostKey(), // TODO: Be secure here.
 	}
 
 	authenticator := webapi.AuthenticatorFromConfig(conf)

--- a/cmd/onboard/main.go
+++ b/cmd/onboard/main.go
@@ -49,9 +49,9 @@ func main() {
 	}
 
 	conf := tunnel.Config{
-		User:    *user,
-		DataDir: dataDir + *user,
-		Signer:  signer,
+		User:            *user,
+		DataDirTemplate: dataDir + *user,
+		Signer:          signer,
 		RemoteConf: config.SatelliteConfiguration{
 			Groundstation: config.Groundstation{"https://", "gpuctl.perial.co.uk", 80},
 			Satellite: config.Satellite{

--- a/internal/webapi/onboard_test.go
+++ b/internal/webapi/onboard_test.go
@@ -32,8 +32,8 @@ func TestOnboardNoKey(t *testing.T) {
 	t.Parallel()
 
 	serv := webapi.NewServer(nil, alwaysAuth{}, tunnel.Config{
-		DataDir: "/foo",
-		User:    "JFK",
+		DataDirTemplate: "/foo",
+		User:            "JFK",
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/admin/add_workstation", strings.NewReader(`{"hostname": "foo.net"}`))
@@ -53,9 +53,9 @@ func TestOnboardNoHostname(t *testing.T) {
 	require.NoError(t, err)
 
 	serv := webapi.NewServer(nil, alwaysAuth{}, tunnel.Config{
-		DataDir: "/foo",
-		User:    "root",
-		Signer:  sign,
+		DataDirTemplate: "/foo",
+		User:            "root",
+		Signer:          sign,
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/admin/add_workstation", strings.NewReader("{}"))


### PR DESCRIPTION
Rather than just using the data directory, combine it with the username we're ssh-ing in as too. This avoids permission issues when subsequent deployments change the user whose ssh key we're using and fail trying to write the new satellite binary to that folder.