### PR TITLE
all: Correct use of time

### DIFF
--- a/cmd/control/control.go
+++ b/cmd/control/control.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"time"
 
 	"golang.org/x/crypto/ssh"
 
@@ -88,9 +87,7 @@ func main() {
 		errs <- fmt.Errorf("downsampler: %w", err)
 	}()
 	go func() {
-		monitorInterval := time.Duration(conf.Timeouts.MonitorInterval) * time.Second
-		deathTimeOut := time.Duration(conf.Timeouts.DeathTimeout) * time.Second
-		err := groundstation.MonitorForDeadMachines(monitorInterval, db, deathTimeOut, log, tunnelConf)
+		err := groundstation.MonitorForDeadMachines(db, conf.Timeouts, log.With(), tunnelConf)
 		errs <- fmt.Errorf("dead machine monitor: %w", err)
 	}()
 

--- a/cmd/onboard/main.go
+++ b/cmd/onboard/main.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"log/slog"
 	"os"
-	"time"
 
 	"golang.org/x/crypto/ssh"
 
@@ -55,8 +54,8 @@ func main() {
 		RemoteConf: config.SatelliteConfiguration{
 			Groundstation: config.Groundstation{"https://", "gpuctl.perial.co.uk", 80},
 			Satellite: config.Satellite{
-				DataInterval:      int(10 * time.Second),
-				HeartbeatInterval: int(5 * time.Second),
+				DataInterval:      10 * config.Second,
+				HeartbeatInterval: 5 * config.Second,
 				FakeGPU:           true,
 				Cache:             "/data/gpuctl/cache",
 			},

--- a/deploy/control.prod.toml
+++ b/deploy/control.prod.toml
@@ -5,13 +5,11 @@ webapi_port = 8000
 [Database]
 postgres = true
 url = "postgres://postgres@postgres/postgres"
-# downsample in nanoseconds
-downsample_interval = 500000000000
+downsample_interval = "10m"
 
 [Timeouts]
-# timeouts in seconds
-death_timeout = 1000
-monitor_interval = 1000
+death_timeout = "60s"
+monitor_interval = "15s"
 
 [Auth]
 username = "admin"
@@ -27,8 +25,7 @@ hostname = "gpuctl.perial.co.uk"
 port = 443
 
 [Onboard.Remote.Satellite]
-# intervals in nanoseconds
-data_interval = 15000000000
-heartbeat_interval = 5000000000
+data_interval = "15s"
+heartbeat_interval = "5s"
 fake_gpu = false
 

--- a/deploy/satellite.example.toml
+++ b/deploy/satellite.example.toml
@@ -4,6 +4,6 @@ hostname = "gpuctl.perial.co.uk"
 port = 443
 
 [Satellite]
-data_interval = 15000000000
-heartbeat_interval = 5000000000
+data_interval = "15s"
+heartbeat_interval = "5s"
 fake_gpu = false

--- a/internal/broadcast/types.go
+++ b/internal/broadcast/types.go
@@ -89,5 +89,5 @@ type RemoveMachineInfo struct {
 // data type returned by queries of when a workstation was last seen
 type WorkstationSeen struct {
 	Hostname string
-	LastSeen int64
+	LastSeen time.Time
 }

--- a/internal/config/duration.go
+++ b/internal/config/duration.go
@@ -1,0 +1,35 @@
+package config
+
+import "time"
+
+type Duration time.Duration
+
+const (
+	Nanosecond  Duration = Duration(time.Nanosecond)
+	Microsecond Duration = Duration(time.Microsecond)
+	Millisecond Duration = Duration(time.Millisecond)
+	Second      Duration = Duration(time.Second)
+	Minute      Duration = Duration(time.Minute)
+	Hour        Duration = Duration(time.Hour)
+)
+
+func (d *Duration) UnmarshalText(text []byte) error {
+	dur, err := time.ParseDuration(string(text))
+
+	if err != nil {
+		return err
+	}
+
+	*d = Duration(dur)
+	return nil
+}
+
+// NewTicker returns a new Ticker containing a channel that will send
+// the current time on the channel after each tick. The period of the
+// ticks is specified by the duration argument. The ticker will adjust
+// the time interval or drop ticks to make up for slow receivers.
+// The duration d must be greater than zero; if not, NewTicker will
+// panic. Stop the ticker to release associated resources.
+func (d Duration) NewTicker() *time.Ticker {
+	return time.NewTicker(time.Duration(d))
+}

--- a/internal/config/duration_test.go
+++ b/internal/config/duration_test.go
@@ -1,0 +1,46 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gpuctl/gpuctl/internal/config"
+)
+
+func TestDecodeTime(t *testing.T) {
+	t.Parallel()
+
+	type Foo struct {
+		A config.Duration
+		B config.Duration
+	}
+
+	var foo Foo
+
+	err := toml.Unmarshal([]byte(`A="3s"
+B="2.5h"`), &foo)
+	require.NoError(t, err)
+
+	assert.Equal(t, foo.A, 3*config.Second)
+	assert.Equal(t, foo.B, 2*config.Hour+30*config.Minute)
+}
+
+func TestDecodeTimeNotPresent(t *testing.T) {
+	t.Parallel()
+
+	type Bar struct {
+		C config.Duration
+		D int
+	}
+
+	bar := Bar{6 * config.Microsecond, 101}
+
+	err := toml.Unmarshal([]byte(`D = 666`), &bar)
+	require.NoError(t, err)
+
+	assert.Equal(t, 6*config.Microsecond, bar.C)
+	assert.Equal(t, 666, bar.D)
+}

--- a/internal/config/groundstation.go
+++ b/internal/config/groundstation.go
@@ -1,20 +1,29 @@
 package config
 
+import "time"
+
 type Server struct {
 	GSPort int `toml:"groundstation_port"`
 	WAPort int `toml:"webapi_port"`
 }
 
 type Timeouts struct {
-	DeathTimeout    int `toml:"death_timeout"`
-	MonitorInterval int `toml:"monitor_interval"`
+	DeathTimeout_    Duration `toml:"death_timeout"`
+	MonitorInterval_ Duration `toml:"monitor_interval"`
+}
+
+func (t Timeouts) DeathTimeout() time.Duration {
+	return time.Duration(t.DeathTimeout_)
+}
+func (t Timeouts) MonitorInterval() time.Duration {
+	return time.Duration(t.MonitorInterval_)
 }
 
 type Database struct {
-	InMemory           bool   `toml:"inmemory"`
-	Postgres           bool   `toml:"postgres"`
-	PostgresUrl        string `toml:"url"`
-	DownsampleInterval int    `toml:"downsample_interval"`
+	InMemory           bool     `toml:"inmemory"`
+	Postgres           bool     `toml:"postgres"`
+	PostgresUrl        string   `toml:"url"`
+	DownsampleInterval Duration `toml:"downsample_interval"`
 }
 
 type AuthConfig struct {

--- a/internal/config/satellite.go
+++ b/internal/config/satellite.go
@@ -7,10 +7,10 @@ type Groundstation struct {
 }
 
 type Satellite struct {
-	Cache             string `toml:"cache"`
-	DataInterval      int    `toml:"data_interval"`
-	HeartbeatInterval int    `toml:"heartbeat_interval"`
-	FakeGPU           bool   `toml:"fake_gpu"`
+	Cache             string   `toml:"cache"`
+	DataInterval      Duration `toml:"data_interval"`
+	HeartbeatInterval Duration `toml:"heartbeat_interval"`
+	FakeGPU           bool     `toml:"fake_gpu"`
 }
 
 type SatelliteConfiguration struct {
@@ -27,8 +27,8 @@ func DefaultSatelliteConfiguration() SatelliteConfiguration {
 		},
 		Satellite: Satellite{
 			Cache:             "/tmp/satellite",
-			DataInterval:      60,
-			HeartbeatInterval: 2,
+			DataInterval:      60 * Second,
+			HeartbeatInterval: 2 * Second,
 			FakeGPU:           false,
 		},
 	}

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -635,7 +635,7 @@ func (conn PostgresConn) LastSeen() ([]broadcast.WorkstationSeen, error) {
 	for rows.Next() {
 		var seen_instance broadcast.WorkstationSeen
 
-		err := rows.Scan(&seen_instance.Hostname, &seen_instance.Hostname)
+		err := rows.Scan(&seen_instance.Hostname, &seen_instance.LastSeen)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+
 	//	"reflect"
 	"strings"
 	"time"
@@ -633,12 +634,8 @@ func (conn PostgresConn) LastSeen() ([]broadcast.WorkstationSeen, error) {
 
 	for rows.Next() {
 		var seen_instance broadcast.WorkstationSeen
-		var t time.Time
 
-		err = rows.Scan(&seen_instance.Hostname, &t)
-
-		seen_instance.LastSeen = t.Unix()
-
+		err := rows.Scan(&seen_instance.Hostname, &seen_instance.Hostname)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/database/prune.go
+++ b/internal/database/prune.go
@@ -3,9 +3,11 @@ package database
 import (
 	"log/slog"
 	"time"
+
+	"github.com/gpuctl/gpuctl/internal/config"
 )
 
-func DownsampleOverTime(interval int, database Database) error {
+func DownsampleOverTime(interval config.Duration, database Database) error {
 	downsampleTicker := time.NewTicker(time.Duration(interval))
 
 	for t := range downsampleTicker.C {

--- a/internal/database/unit_test.go
+++ b/internal/database/unit_test.go
@@ -305,8 +305,8 @@ func multipleHeartbeats(t *testing.T, db database.Database) {
 
 func testLastSeen1(t *testing.T, db database.Database) {
 	host := "TestHost"
-	lastSeenTime := time.Now().Unix()
-	db.UpdateLastSeen(host, lastSeenTime)
+	lastSeenTime := time.Now()
+	db.UpdateLastSeen(host, lastSeenTime.Unix())
 
 	lastSeenData, err := db.LastSeen()
 	if err != nil {
@@ -315,21 +315,26 @@ func testLastSeen1(t *testing.T, db database.Database) {
 
 	found := false
 	for _, data := range lastSeenData {
-		if data.Hostname == host && data.LastSeen == lastSeenTime {
+		if data.Hostname == host &&
+			data.LastSeen.Unix() == lastSeenTime.Unix() {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("Last seen data for host %s was not updated correctly", host)
+		t.Errorf("For host %s wanted to find %#v, but data only had %#v", host, lastSeenTime, lastSeenData)
 	}
 }
 
 func testLastSeen2(t *testing.T, db database.Database) {
-	err := db.UpdateLastSeen("foo", 1234567890)
+
+	t1 := time.Date(1, 2, 3, 4, 5, 6, 0, time.Local)
+	t2 := time.Date(7, 8, 9, 10, 11, 12, 0, time.Local)
+
+	err := db.UpdateLastSeen("foo", t1.Unix())
 	assert.NoError(t, err)
 
-	err = db.UpdateLastSeen("bar", 9876543210)
+	err = db.UpdateLastSeen("bar", t2.Unix())
 	assert.NoError(t, err)
 
 	seen, err := db.LastSeen()
@@ -337,8 +342,8 @@ func testLastSeen2(t *testing.T, db database.Database) {
 	assert.Len(t, seen, 2)
 
 	expected := []broadcast.WorkstationSeen{
-		{Hostname: "foo", LastSeen: 1234567890},
-		{Hostname: "bar", LastSeen: 9876543210},
+		{Hostname: "foo", LastSeen: t1.Round(time.Second)},
+		{Hostname: "bar", LastSeen: t2.Round(time.Second)},
 	}
 
 	assert.ElementsMatch(t, expected, seen)

--- a/internal/database/unit_test.go
+++ b/internal/database/unit_test.go
@@ -328,8 +328,8 @@ func testLastSeen1(t *testing.T, db database.Database) {
 
 func testLastSeen2(t *testing.T, db database.Database) {
 
-	t1 := time.Date(1, 2, 3, 4, 5, 6, 0, time.Local)
-	t2 := time.Date(7, 8, 9, 10, 11, 12, 0, time.Local)
+	t1 := time.Date(1, 2, 3, 4, 5, 6, 0, time.UTC)
+	t2 := time.Date(7, 8, 9, 10, 11, 12, 0, time.UTC)
 
 	err := db.UpdateLastSeen("foo", t1.Unix())
 	assert.NoError(t, err)

--- a/internal/database/unit_test.go
+++ b/internal/database/unit_test.go
@@ -346,7 +346,10 @@ func testLastSeen2(t *testing.T, db database.Database) {
 		{Hostname: "bar", LastSeen: t2.Round(time.Second)},
 	}
 
-	assert.ElementsMatch(t, expected, seen)
+	assert.Equal(t, expected[0].Hostname, "foo")
+	assert.Equal(t, expected[1].Hostname, "bar")
+	assert.True(t, t1.Equal(expected[0].LastSeen))
+	assert.True(t, t2.Equal(expected[1].LastSeen))
 }
 
 func testAppendDataPointMissingGPU(t *testing.T, db database.Database) {

--- a/internal/groundstation/autocontact_test.go
+++ b/internal/groundstation/autocontact_test.go
@@ -158,6 +158,12 @@ func TestMonitor(t *testing.T) {
 }
 
 func TestMonitorCantSSH(t *testing.T) {
+	t.Parallel()
+	// TODO: Mock out pinger to allow this.
+	if os.Getenv("CI") != "" {
+		t.Skip("Cannot ping on CI")
+	}
+
 	db := database.InMemory()
 
 	logger := slog.Default()

--- a/internal/groundstation/autocontact_test.go
+++ b/internal/groundstation/autocontact_test.go
@@ -1,6 +1,8 @@
 package groundstation
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"errors"
 	"log/slog"
 	"os"
@@ -11,9 +13,14 @@ import (
 	"github.com/gpuctl/gpuctl/internal/database"
 	"github.com/gpuctl/gpuctl/internal/tunnel"
 	"github.com/gpuctl/gpuctl/internal/uplink"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
 )
 
 type ErrorDB struct{}
+
+var errorDbNotImplemented = errors.New("database error: using errorDB")
 
 func (edb *ErrorDB) UpdateLastSeen(host string, time int64) error {
 	return nil
@@ -32,7 +39,7 @@ func (edb *ErrorDB) LatestData() (broadcast.Workstations, error) {
 }
 
 func (edb *ErrorDB) LastSeen() ([]broadcast.WorkstationSeen, error) {
-	return nil, errors.New("database error")
+	return nil, errorDbNotImplemented
 }
 
 func (edb *ErrorDB) NewMachine(machine broadcast.NewMachine) error {
@@ -73,6 +80,8 @@ func (edb *ErrorDB) RemoveFile(rem broadcast.RemoveFile) error {
 }
 
 func TestPing(t *testing.T) {
+	t.Parallel()
+
 	logger := slog.Default()
 
 	// This is non-routable as per RFC 5737
@@ -86,7 +95,9 @@ func TestPing(t *testing.T) {
 }
 
 func TestPingHappy(t *testing.T) {
-	if testing.Short() || os.Getenv("CI") != "" {
+	t.Parallel()
+
+	if os.Getenv("CI") != "" {
 		t.Skip("Skipping ping test in short mode or CI environment")
 	}
 
@@ -101,35 +112,66 @@ func TestPingHappy(t *testing.T) {
 	}
 }
 
+func sshConfig(t *testing.T) tunnel.Config {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	require.NoError(t, err)
+
+	return tunnel.Config{User: "testuser", Signer: signer}
+
+}
+
 func TestMonitorWithErrorDB(t *testing.T) {
 	db := &ErrorDB{}
 	logger := slog.Default()
 
-	sshConfig := tunnel.Config{User: "testuser"}
-
 	currentTime := time.Now()
-	timespanForDeath := 24 * time.Hour
+	cutoffTime := currentTime.Add(-24 * time.Hour)
 
-	err := monitor(db, currentTime, timespanForDeath, logger, sshConfig)
-	if err == nil {
+	sshConfig := sshConfig(t)
+
+	err := monitor(db, cutoffTime, logger, sshConfig)
+	if !errors.Is(err, errorDbNotImplemented) {
 		t.Fatal("Expected monitor to return an error due to ErrorDB.LastSeen, but it did not")
 	}
 }
 
 func TestMonitor(t *testing.T) {
 	db := database.InMemory()
+
+	// logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	logger := slog.Default()
 
-	sshConfig := tunnel.Config{User: "testuser"}
+	sshConfig := sshConfig(t)
 
 	currentTime := time.Now()
 	db.UpdateLastSeen("machineRecent", currentTime.Unix())                 // This machine should not trigger any action
 	db.UpdateLastSeen("machineOld", currentTime.Add(-48*time.Hour).Unix()) // This machine should trigger actions
 
-	timespanForDeath := 24 * time.Hour
+	cutoffTime := currentTime.Add(-24 * time.Hour)
+	err := monitor(db, cutoffTime, logger, sshConfig)
 
-	err := monitor(db, currentTime, timespanForDeath, logger, sshConfig)
-	if err != nil {
-		t.Fatalf("Monitor encountered an error: %v", err)
+	assert.NoError(t, err, "Shouldn't attempt to contact any machines")
+}
+
+func TestMonitorCantSSH(t *testing.T) {
+	db := database.InMemory()
+
+	logger := slog.Default()
+
+	sshConfig := sshConfig(t)
+
+	currentTime := time.Now()
+	db.UpdateLastSeen("google.com", currentTime.Add(-48*time.Hour).Unix()) // This machine should trigger actions
+
+	cutoffTime := currentTime.Add(-24 * time.Hour)
+	err := monitor(db, cutoffTime, logger, sshConfig)
+
+	if err == nil {
+		t.Fatal("Expected an error")
 	}
+
 }


### PR DESCRIPTION
Means the config is readable, and should fix dead-machine-monitor.

r? @danielg0 

cc @Euphoride 