### PR TITLE
deploy: Run control as multi-stage alpine build.

### DIFF
--- a/deploy/control.Dockerfile
+++ b/deploy/control.Dockerfile
@@ -1,6 +1,7 @@
-FROM docker.io/golang:1.22
+FROM docker.io/golang:1.22-alpine as build
 
 WORKDIR /gpuctl
+RUN apk add make
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 
@@ -10,6 +11,11 @@ COPY Makefile Makefile
 
 RUN make control
 
+FROM docker.io/alpine:latest
+
+WORKDIR /gpuctl
+
+COPY --from=build /gpuctl/control control
 COPY ./deploy/control.prod.toml ./control.toml
 
 ENTRYPOINT ["./control"]


### PR DESCRIPTION
This makes images smaller, and means that we have the ping binary on the running
machine.
