### PR TITLE
Tidy up group & info management

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "match-sorter": "^6.3.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^5.0.1",
         "react-router-dom": "^6.22.0",
         "react-scripts": "^5.0.1",
         "sort-by": "^1.2.0",
@@ -17844,6 +17845,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "match-sorter": "^6.3.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.0.1",
     "react-router-dom": "^6.22.0",
     "react-scripts": "^5.0.1",
     "sort-by": "^1.2.0",

--- a/frontend/src/Components/EditableFields.tsx
+++ b/frontend/src/Components/EditableFields.tsx
@@ -3,6 +3,7 @@ import {
   EditableInput,
   EditablePreview,
   HStack,
+  Flex,
   IconButton,
   Td,
 } from "@chakra-ui/react";
@@ -67,46 +68,48 @@ export const EditableField = ({
   // https://github.com/gpuctl/gpuctl/pull/220
   // Go back there if you want to re-implement it
   return (
-    <Td>
-      {fieldKey === "group" ? (
-        <Editable
-          defaultValue={group}
-          placeholder={placeholder}
-          textColor={pickCol(group)}
-          onSubmit={(a) => {
-            handleSubmit(a);
-          }}
-        >
-          {(props) => (
-            <HStack>
-              <EditablePreview isTruncated />
-              <EditableInput width="10rem" />
-              <EditableButton {...props} />
-            </HStack>
-          )}
-        </Editable>
-      ) : (
-        <Editable
-          defaultValue={
-            workstation[fieldKey as keyof WorkStationData] as string
-          }
-          placeholder={placeholder}
-          textColor={pickCol(
-            workstation[fieldKey as keyof WorkStationData] as string,
-          )}
-          onSubmit={(a) => {
-            handleSubmit(a);
-          }}
-        >
-          {(props) => (
-            <HStack>
-              <EditablePreview isTruncated />
-              <EditableInput />
-              <EditableButton {...props} />
-            </HStack>
-          )}
-        </Editable>
-      )}
+    <Td pr="0">
+      <Flex min-width="5rem">
+        {fieldKey === "group" ? (
+          <Editable
+            defaultValue={group}
+            placeholder={placeholder}
+            textColor={pickCol(group)}
+            onSubmit={(a) => {
+              handleSubmit(a);
+            }}
+          >
+            {(props) => (
+              <HStack>
+                <EditablePreview isTruncated />
+                <EditableInput />
+                <EditableButton {...props} />
+              </HStack>
+            )}
+          </Editable>
+        ) : (
+          <Editable
+            defaultValue={
+              workstation[fieldKey as keyof WorkStationData] as string
+            }
+            placeholder={placeholder}
+            textColor={pickCol(
+              workstation[fieldKey as keyof WorkStationData] as string,
+            )}
+            onSubmit={(a) => {
+              handleSubmit(a);
+            }}
+          >
+            {(props) => (
+              <HStack>
+                <EditablePreview isTruncated />
+                <EditableInput />
+                <EditableButton {...props} />
+              </HStack>
+            )}
+          </Editable>
+        )}
+      </Flex>
     </Td>
   );
 };

--- a/frontend/src/Components/GroupInfoManagement.tsx
+++ b/frontend/src/Components/GroupInfoManagement.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from "react";
+import { FaRegCopy } from "react-icons/fa6";
 import {
   Box,
   Button,
+  ButtonGroup,
   Heading,
   Table,
   TableContainer,
@@ -192,15 +194,13 @@ export const GroupInfoManagement = ({
         <Table variant="striped">
           <Thead>
             <Tr>
-              <Th width="10rem">Hostname</Th>
-              <Th width="10rem">Group</Th>
-              <Th width="15rem">CPU</Th>
-              <Th width="15rem">Motherboard</Th>
-              <Th width="15rem">Notes</Th>
-              <Th width="10rem">Owner</Th>
-              <Th>Files</Th>
-              <Th>Shutdown </Th>
-              <Th>Remove</Th>
+              <Th>Hostname</Th>
+              <Th>Group</Th>
+              <Th>Owner</Th>
+              <Th>CPU</Th>
+              <Th>Motherboard</Th>
+              <Th>Notes</Th>
+              <Th>Actions</Th>
             </Tr>
           </Thead>
           <Tbody>
@@ -214,7 +214,7 @@ export const GroupInfoManagement = ({
 
                   return (
                     <Tr key={workstation.name}>
-                      <Td>
+                      <Td min-width="5rem">
                         {" "}
                         <Link
                           as={ReactRouterLink}
@@ -233,6 +233,13 @@ export const GroupInfoManagement = ({
                       <EditableField
                         group={group.name}
                         workstation={workstation}
+                        fieldKey="owner"
+                        placeholder="none"
+                        isEven={k % 2 === 0}
+                      />
+                      <EditableField
+                        group={group.name}
+                        workstation={workstation}
                         fieldKey="cpu"
                         placeholder="unknown"
                         isEven={k % 2 === 0}
@@ -246,7 +253,7 @@ export const GroupInfoManagement = ({
                       />
                       <Td>
                         <HStack>
-                          <Text isTruncated maxWidth="10rem">
+                          <Text isTruncated maxWidth="15rem">
                             {" "}
                             {workstation.notes}{" "}
                           </Text>
@@ -257,39 +264,37 @@ export const GroupInfoManagement = ({
                           />
                         </HStack>
                       </Td>
-                      <EditableField
-                        group={group.name}
-                        workstation={workstation}
-                        fieldKey="owner"
-                        placeholder="none"
-                        isEven={k % 2 === 0}
-                      />
                       <Td>
-                        <Button
-                          colorScheme="green"
-                          onClick={handleViewFiles(workstation.name)}
-                        >
-                          Files
-                        </Button>
-                      </Td>
-                      <Td>
-                        <Button
-                          colorScheme="blue"
-                          onClick={() => handleShutdownClick(workstation.name)}
-                          disabled={copied}
-                        >
-                          {copied && workstation.name === currentMachine
-                            ? "Copied"
-                            : "Copy"}
-                        </Button>
-                      </Td>
-                      <Td>
-                        <Button
-                          colorScheme="red"
-                          onClick={() => removeMachine(workstation.name)}
-                        >
-                          Remove
-                        </Button>
+                        <ButtonGroup>
+                          <Button
+                            colorScheme="green"
+                            onClick={handleViewFiles(workstation.name)}
+                          >
+                            Files
+                          </Button>
+                          <Button
+                            colorScheme="blue"
+                            onClick={() =>
+                              handleShutdownClick(workstation.name)
+                            }
+                            disabled={copied}
+                          >
+                            {copied && workstation.name === currentMachine ? (
+                              <HStack>
+                                {" "}
+                                <Text> Copied </Text> <FaRegCopy />{" "}
+                              </HStack>
+                            ) : (
+                              "Shutdown"
+                            )}
+                          </Button>
+                          <Button
+                            colorScheme="red"
+                            onClick={() => removeMachine(workstation.name)}
+                          >
+                            Remove
+                          </Button>
+                        </ButtonGroup>
                       </Td>
                     </Tr>
                   );

--- a/frontend/src/Components/NotesPopout.tsx
+++ b/frontend/src/Components/NotesPopout.tsx
@@ -50,8 +50,9 @@ export const NotesPopout = ({
         <PopoverArrow />
         <PopoverCloseButton />
         <PopoverHeader>Notes: {wname}</PopoverHeader>
-        <PopoverBody>
+        <PopoverBody height="15rem">
           <Textarea
+            height="100%"
             value={newNotes}
             onChange={(s) => {
               setNewNotes(s.target.value);


### PR DESCRIPTION
Give items a minimum width so editing doesn't shrink it (closes #278). Also change the spacing and padding to make it a bit tighter and vaguelly usable on phones.

Make the note popover bigger

Group actions into one column